### PR TITLE
Use static shape where available in TensorFlow backend

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -400,8 +400,13 @@ class TensorflowBackend(AbstractBackend):
     def shape(self, x):
         if self.tf.executing_eagerly():
             return tuple(int(d) for d in x.shape)
-        else:
-            return tuple(self.tf.unstack(self.tf.shape(x)))
+        else: 
+            static_shape = x.shape.as_list()
+            tf_shape = self.tf.shape(x)
+
+            # use the static shape where known, otherwise use the TF shape
+            shape = [s or tf_shape[dim] for dim, s in enumerate(static_shape)]
+            return tuple(shape)
 
     def reduce(self, x, operation, axes):
         return getattr(self.tf, 'reduce_' + operation)(x, axis=axes)


### PR DESCRIPTION
When running in graph mode, TensorFlow tensors have two types of shapes:
  - a static shape, known when the graph is built
  - a dynamic shape, only known when the graph is run

The static shape is important especially for the channels dimension, since the number of variables needed for a convolution depends on this shape.

In the current implementation, `einops` uses only the dynamic shape in graph execution mode, which means that static shape information is lost after calling one of the einops functions. I have updated the TensorFlow backend to only use dynamic shape information for dimensions where the static shape is unknown.