### PR TITLE
Refactor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ dist: xenial
 language: generic
 matrix:
   include:
-  - name: python3.5
-    env: DOCKERIMAGE=python:3.5-stretch
-  - name: python3.7
-    env: DOCKERIMAGE=python:3.7-stretch
+  - name: python3.6
+    env: DOCKERIMAGE=python:3.6-stretch
+  - name: python3.8
+    env: DOCKERIMAGE=python:3.8-stretch
 install:
   - docker pull $DOCKERIMAGE
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   - name: python3.6
     env: DOCKERIMAGE=python:3.6-stretch
   - name: python3.8
-    env: DOCKERIMAGE=python:3.8-stretch
+    env: DOCKERIMAGE=python:3.8-buster
 install:
   - docker pull $DOCKERIMAGE
 script:

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -211,9 +211,6 @@ class TransformRecipe:
         return backend.reshape(tensor, final_shapes)
 
 
-
-
-# TODO add logaddexp, std, var, ptp, l1, l2
 @functools.lru_cache(256)
 def _prepare_transformation_recipe(pattern: str,
                                    operation: Reduction,

--- a/einops/layers/keras.py
+++ b/einops/layers/keras.py
@@ -2,16 +2,29 @@ from keras.engine import Layer
 
 from .._backends import UnknownSize
 from . import RearrangeMixin, ReduceMixin
+import warnings
 
 __author__ = 'Alex Rogozhnikov'
+
+warnings.warn(
+    'Keras does not exist anymore as an independent framework, '
+    'these layers (targeted at old multi-framework keras) will be removed, '
+    'please use einops.layers.tensorflow.',
+    DeprecationWarning,
+)
+
+
+def _compute_output_shape(self, input_shape):
+    input_shape = tuple(UnknownSize() if d is None else int(d) for d in input_shape)
+    init_shapes, reduced_axes, axes_reordering, added_axes, final_shape = \
+        self.recipe().reconstruct_from_shape(input_shape)
+    final_shape = tuple(None if isinstance(d, UnknownSize) else int(d) for d in final_shape)
+    return final_shape
 
 
 class Rearrange(RearrangeMixin, Layer):
     def compute_output_shape(self, input_shape):
-        input_shape = tuple(UnknownSize() if d is None else int(d) for d in input_shape)
-        init_shapes, reduced_axes, axes_reordering, final_shape = self.recipe().reconstruct_from_shape(input_shape)
-        final_shape = tuple(None if isinstance(d, UnknownSize) else int(d) for d in final_shape)
-        return final_shape
+        return _compute_output_shape(self, input_shape)
 
     def call(self, inputs):
         return self._apply_recipe(inputs)
@@ -22,10 +35,7 @@ class Rearrange(RearrangeMixin, Layer):
 
 class Reduce(ReduceMixin, Layer):
     def compute_output_shape(self, input_shape):
-        input_shape = tuple(UnknownSize() if d is None else int(d) for d in input_shape)
-        init_shapes, reduced_axes, axes_reordering, final_shape = self.recipe().reconstruct_from_shape(input_shape)
-        final_shape = tuple(None if isinstance(d, UnknownSize) else int(d) for d in final_shape)
-        return final_shape
+        return _compute_output_shape(self, input_shape)
 
     def call(self, inputs):
         return self._apply_recipe(inputs)

--- a/test.py
+++ b/test.py
@@ -31,8 +31,7 @@ if have_cuda:
 
 # install dependencies
 dependencies = [
-    # TODO remove numpy version
-    'numpy==1.18.4',
+    'numpy',
     'mxnet',
     'torch',
     'tensorflow',
@@ -51,11 +50,5 @@ assert 0 == run('pip install {} --pre --progress-bar off'.format(' '.join(depend
 assert 0 == run('pip install -e .')
 
 
-# we need to run tests twice
-# - once for tensorflow eager
-return_code1 = run('python -m nose tests -vds', TF_EAGER='1', EINOPS_SKIP_CUPY='0' if have_cuda else '1')
-print('\n' * 5)
-# - and once for symbolic tensorflow
-return_code2 = run('python -m nose tests -vds', TF_EAGER='0', EINOPS_SKIP_CUPY='0' if have_cuda else '1')
-
-assert return_code1 == 0 and return_code2 == 0
+return_code = run('python -m nose tests -vds', EINOPS_SKIP_CUPY='0' if have_cuda else '1')
+assert return_code == 0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,63 +11,51 @@ import logging
 logging.getLogger('tensorflow').disabled = True
 logging.getLogger('matplotlib').disabled = True
 
-assert os.environ.get('TF_EAGER', '') in ['', '1', '0']
 assert os.environ.get('EINOPS_SKIP_CUPY', '') in ['', '1', '0']
 skip_cupy = os.environ.get('EINOPS_SKIP_CUPY', '') == '1'
-
-
-if os.environ.get('TF_EAGER', '') == '1':
-    try:
-        import tensorflow
-        tensorflow.enable_eager_execution()
-        print('testing with eager execution')
-    except:
-        pass
 
 
 def collect_test_backends(symbolic=False, layers=False):
     """
     :param symbolic: symbolic or imperative frameworks?
-    :param layers: layers or operation?
+    :param layers: layers or operations?
     :return: list of backends satisfying set conditions
     """
-    tf_running_eagerly = True
-    try:
-        import tensorflow
-        tf_running_eagerly = tensorflow.executing_eagerly()
-    except ImportError:
-        print("Couldn't import tensorflow for testing")
-
     if not symbolic:
         if not layers:
-            backend_types = [_backends.NumpyBackend,
-                             _backends.JaxBackend,
-                             _backends.TorchBackend,
-                             _backends.GluonBackend,
-                             _backends.ChainerBackend,
-                             ]
-            if tf_running_eagerly:
-                backend_types += [_backends.TensorflowBackend]
+            backend_types = [
+                _backends.NumpyBackend,
+                _backends.JaxBackend,
+                _backends.TorchBackend,
+                _backends.GluonBackend,
+                _backends.ChainerBackend,
+                _backends.TensorflowBackend,
+            ]
             if not skip_cupy:
                 backend_types += [_backends.CupyBackend]
         else:
-            backend_types = [_backends.TorchBackend,
-                             _backends.GluonBackend,
-                             _backends.ChainerBackend]
+            backend_types = [
+                _backends.TorchBackend,
+                _backends.GluonBackend,
+                _backends.ChainerBackend,
+            ]
     else:
         if not layers:
-            backend_types = [_backends.MXNetBackend]
-            if not tf_running_eagerly:
-                backend_types += [_backends.TensorflowBackend]
+            backend_types = [
+                _backends.MXNetBackend,
+            ]
         else:
-            backend_types = [_backends.MXNetBackend]
-            if not tf_running_eagerly:
-                backend_types += [_backends.KerasBackend]
+            backend_types = [
+                _backends.MXNetBackend,
+                _backends.KerasBackend,
+            ]
 
     result = []
     for backend_type in backend_types:
         try:
             result.append(backend_type())
         except ImportError:
+            # problem with backend installation fails a specific test function,
+            # but will be skipped in all other test cases
             warnings.warn('backend could not be initialized for tests: {}'.format(backend_type))
     return result

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -190,7 +190,7 @@ def test_reduce_symbolic():
 
                     if 'keras' not in backend.framework_name:
                         # simple pickling / unpickling
-                        # keras bug - fails for pickling
+                        # keras bug - fails for pickling, requires special import/export
                         layer2 = pickle.loads(pickle.dumps(layer))
                         result_symbol2 = layer2(symbol)
                         result2 = backend.eval_symbol(result_symbol2, eval_inputs)
@@ -245,7 +245,7 @@ def test_torch_layer():
         torch.testing.assert_allclose(model1(input), model3(input), atol=1e-3, rtol=1e-3)
         torch.testing.assert_allclose(model1(input + 1), model3(input + 1), atol=1e-3, rtol=1e-3)
 
-        model4 = torch.jit.trace(model2, example_inputs=input, optimize=True)
+        model4 = torch.jit.trace(model2, example_inputs=input)
         torch.testing.assert_allclose(model1(input), model4(input), atol=1e-3, rtol=1e-3)
         torch.testing.assert_allclose(model1(input + 1), model4(input + 1), atol=1e-3, rtol=1e-3)
 


### PR DESCRIPTION
- adjustments for tf being in eager mode by default
- more stable shape inference for tf symbols
- deprecate keras layers
- single run of tests (previously had to run independently for eager and non-eager modes)