### PR TITLE
Add 'repeat' to import __all__

### DIFF
--- a/einops/__init__.py
+++ b/einops/__init__.py
@@ -7,6 +7,6 @@ class EinopsError(RuntimeError):
     pass
 
 
-__all__ = ['rearrange', 'reduce', 'parse_shape', 'asnumpy', 'EinopsError']
+__all__ = ['rearrange', 'reduce', 'repeat', 'parse_shape', 'asnumpy', 'EinopsError']
 
 from .einops import rearrange, reduce, repeat, parse_shape, asnumpy


### PR DESCRIPTION
`'repeat'` was missing from the `__all__` list in `__init__.py` even though it's imported. Some IDEs (e.g. PyCharm) treat it as warning. This is a very minor fix.