### PR TITLE
Adds example of inferring dimensions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ output_tensor = rearrange(input_tensor, 't b c -> b c t')
 output_tensor = reduce(input_tensor, 'b c (h h2) (w w2) -> b h w c', 'mean', h2=2, w2=2)
 # copy along a new axis 
 output_tensor = repeat(input_tensor, 'h w -> h w c', c=3)
+# infer dimensions automatically
+output_tensor = rearrange(input_tensor, '... h w -> ... w h')
 ```
 And two corresponding layers (`einops` keeps a separate version for each framework) with the same API.
 


### PR DESCRIPTION
This feature is a nugget that might be obvious to some but is hidden in any documentation that I am able to find.

My edit might be on the nose of the readme but I otherwise suggest to include some other example to showcase inference of dimensions, e.g.:

```python
image_sample = torch.rand([3, 256, 256])
image_batch = torch.rand([10, 3, 256, 256])

def make_grayscale(t):
    return reduce(t, "... c h w -> ... h w", "mean")

image_sample_gray = make_grayscale(image_sample)
image_batch_gray = make_grayscale(image_batch)

print(image_sample_gray.shape)
print(image_batch_gray.shape)

> [256, 256]
> [10, 256, 256]
```