### PR TITLE
Reject repeated axes in parse_shape

### DIFF
--- a/einops/einops.py
+++ b/einops/einops.py
@@ -562,13 +562,16 @@ def parse_shape(x, pattern: str):
     Returns:
         dict, maps axes names to their lengths
     """
-    names = [elementary_axis for elementary_axis in pattern.split(' ') if len(elementary_axis) > 0]
+    exp = ParsedExpression(pattern, allow_underscore=True)
     shape = get_backend(x).shape(x)
-    if len(shape) != len(names):
+    if exp.has_composed_axes():
+        raise RuntimeError("Can't parse shape with composite axes: {pattern} {shape}".format(
+            pattern=pattern, shape=shape))
+    if len(shape) != len(exp.composition):
         raise RuntimeError("Can't parse shape with different number of dimensions: {pattern} {shape}".format(
             pattern=pattern, shape=shape))
     result = {}
-    for axis_name, axis_length in zip(names, shape):
+    for (axis_name, ), axis_length in zip(exp.composition, shape):
         if axis_name != '_':
             result[axis_name] = axis_length
     return result

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2,6 +2,7 @@ import sys
 from doctest import testmod
 
 import numpy
+from nose.tools import assert_raises
 
 import einops
 import einops.layers
@@ -92,6 +93,9 @@ def test_parse_shape_imperative():
         parsed2 = parse_shape(backend.from_numpy(x), '_ _ a1 a1a111a')
         assert parsed1 == parsed2 == dict(a1=30, a1a111a=40)
 
+        with assert_raises(einops.EinopsError):
+            parse_shape(x, 'a a b b')
+
 
 def test_parse_shape_symbolic():
     backends = collect_test_backends(symbolic=True, layers=False)
@@ -137,3 +141,8 @@ def test_is_float_type():
             if 'chainer' in backend.framework_name and not is_float:
                 continue  # chainer doesn't allow non-floating tensors
             assert backend.is_float_type(input) == is_float, (dtype, backend, input.dtype)
+
+
+if __name__ == "__main__":
+    parse_shape(numpy.zeros((10, 20, 40)), 'asdf')
+    test_parse_shape_imperative()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -141,8 +141,3 @@ def test_is_float_type():
             if 'chainer' in backend.framework_name and not is_float:
                 continue  # chainer doesn't allow non-floating tensors
             assert backend.is_float_type(input) == is_float, (dtype, backend, input.dtype)
-
-
-if __name__ == "__main__":
-    parse_shape(numpy.zeros((10, 20, 40)), 'asdf')
-    test_parse_shape_imperative()


### PR DESCRIPTION
This implementation reuses the machinery of `ParsedExpression` to ensure that the patterns are parsed the same for all the functions in the API of einops.

I had to add a new option `allow_underscore` to the `ParsedExpression`.

Fixes #158