### PR TITLE
[WIP] Enable ellipsis in patterns for parse_shape.

### DIFF
--- a/einops/einops.py
+++ b/einops/einops.py
@@ -568,10 +568,22 @@ def parse_shape(x, pattern: str):
         raise RuntimeError("Can't parse shape with composite axes: {pattern} {shape}".format(
             pattern=pattern, shape=shape))
     if len(shape) != len(exp.composition):
-        raise RuntimeError("Can't parse shape with different number of dimensions: {pattern} {shape}".format(
-            pattern=pattern, shape=shape))
+        if exp.has_ellipsis:
+            if len(shape) < len(exp.composition) - 1:
+                raise RuntimeError("Can't parse shape with this number of dimensions: {pattern} {shape}".format(
+                    pattern=pattern, shape=shape))
+        else:
+            raise RuntimeError("Can't parse shape with different number of dimensions: {pattern} {shape}".format(
+                pattern=pattern, shape=shape))
+    if exp.has_ellipsis:
+        ellipsis_idx = exp.composition.index(_ellipsis)
+        composition = (exp.composition[:ellipsis_idx] +
+                       ['_'] * (len(shape) - len(exp.composition) + 1) +
+                       exp.composition[ellipsis_idx+1:])
+    else:
+        composition = exp.composition
     result = {}
-    for (axis_name, ), axis_length in zip(exp.composition, shape):
+    for (axis_name, ), axis_length in zip(composition, shape):
         if axis_name != '_':
             result[axis_name] = axis_length
     return result

--- a/test.py
+++ b/test.py
@@ -41,6 +41,7 @@ dependencies = [
     'nbformat',
     'nbconvert',
     'jupyter',
+    'parameterized',
     'pillow',
     'nose',
 ]


### PR DESCRIPTION
Now parse_shape can accept ellipsis the same as other operations.

For example,
`parse_shape(np.zeros((10, 20, 30, 40)), 'a ... b')`
returns
`dict(a=10, b=40)`

TODO:
- [x] add documentation

Fixes #161