### PR TITLE
Create einsum operation

### DIFF
--- a/einops/__init__.py
+++ b/einops/__init__.py
@@ -7,6 +7,7 @@ class EinopsError(RuntimeError):
     pass
 
 
-__all__ = ['rearrange', 'reduce', 'repeat', 'parse_shape', 'asnumpy', 'EinopsError']
+__all__ = ['rearrange', 'reduce', 'repeat', 'einsum',
+           'parse_shape', 'asnumpy', 'EinopsError']
 
-from .einops import rearrange, reduce, repeat, parse_shape, asnumpy
+from .einops import rearrange, reduce, repeat, einsum, parse_shape, asnumpy

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -89,9 +89,6 @@ class AbstractBackend:
     def reduce(self, x, operation, axes):
         return getattr(x, operation)(axis=axes)
 
-    def einsum(self, pattern, *x):
-        raise NotImplementedError("backend does not support einsum")
-
     def stack_on_zeroth_dimension(self, tensors: list):
         raise NotImplementedError()
 
@@ -119,6 +116,9 @@ class AbstractBackend:
 
     def __repr__(self):
         return "<einops backend for {}>".format(self.framework_name)
+
+    def einsum(self, pattern, *x):
+        raise NotImplementedError("backend does not support einsum")
 
 
 class UnknownSize:
@@ -394,6 +394,9 @@ class CupyBackend(AbstractBackend):
     def is_float_type(self, x):
         return x.dtype in ('float16', 'float32', 'float64', 'float128')
 
+    def einsum(self, pattern, *x):
+        return self.cupy.einsum(pattern, *x)
+
 
 class ChainerBackend(AbstractBackend):
     framework_name = 'chainer'
@@ -436,6 +439,9 @@ class ChainerBackend(AbstractBackend):
     def layers(self):
         from .layers import chainer
         return chainer
+
+    def einsum(self, pattern, *x):
+        return self.chainer.functions.einsum(pattern, *x)
 
 
 class HashableTuple:
@@ -572,6 +578,9 @@ class KerasBackend(AbstractBackend):
         from .layers import keras
         return keras
 
+    def einsum(self, pattern, *x):
+        return self.tf.einsum(pattern, *x)
+
 
 class OneFlowBackend(AbstractBackend):
     framework_name = "oneflow"
@@ -634,3 +643,6 @@ class OneFlowBackend(AbstractBackend):
     def layers(self):
         from .layers import oneflow
         return oneflow
+
+    def einsum(self, pattern, *x):
+        return self.flow.einsum(pattern, *x)

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -236,9 +236,6 @@ class GluonBackend(AbstractBackend):
         from .layers import gluon
         return gluon
 
-    def einsum(self, pattern, *x):
-        return self.mx.np.einsum(pattern, *x)
-
 
 class MXNetBackend(AbstractBackend):
     framework_name = 'mxnet.symbol'
@@ -299,9 +296,6 @@ class MXNetBackend(AbstractBackend):
     def layers(self):
         from .layers import gluon
         return gluon
-
-    def einsum(self, pattern, *x):
-        return self.mx.np.einsum(pattern, *x)
 
 
 class TorchBackend(AbstractBackend):

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -236,6 +236,9 @@ class GluonBackend(AbstractBackend):
         from .layers import gluon
         return gluon
 
+    def einsum(self, pattern, *x):
+        return self.mx.np.einsum(pattern, *x)
+
 
 class MXNetBackend(AbstractBackend):
     framework_name = 'mxnet.symbol'
@@ -296,6 +299,9 @@ class MXNetBackend(AbstractBackend):
     def layers(self):
         from .layers import gluon
         return gluon
+
+    def einsum(self, pattern, *x):
+        return self.mx.np.einsum(pattern, *x)
 
 
 class TorchBackend(AbstractBackend):

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -89,6 +89,9 @@ class AbstractBackend:
     def reduce(self, x, operation, axes):
         return getattr(x, operation)(axis=axes)
 
+    def einsum(self, pattern, *x):
+        raise NotImplementedError("backend does not support einsum")
+
     def stack_on_zeroth_dimension(self, tensors: list):
         raise NotImplementedError()
 
@@ -167,6 +170,9 @@ class NumpyBackend(AbstractBackend):
 
     def add_axis(self, x, new_position):
         return self.np.expand_dims(x, new_position)
+
+    def einsum(self, pattern, *x):
+        return self.np.einsum(pattern, *x)
 
 
 class JaxBackend(NumpyBackend):
@@ -353,6 +359,9 @@ class TorchBackend(AbstractBackend):
         from .layers import torch
         return torch
 
+    def einsum(self, pattern, *x):
+        return self.torch.einsum(pattern, *x)
+
 
 class CupyBackend(AbstractBackend):
     framework_name = 'cupy'
@@ -506,6 +515,9 @@ class TensorflowBackend(AbstractBackend):
     def layers(self):
         from .layers import tensorflow
         return tensorflow
+
+    def einsum(self, pattern, *x):
+        return self.tf.einsum(pattern, *x)
 
 
 class KerasBackend(AbstractBackend):

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -688,3 +688,9 @@ def _compatify_pattern_for_einsum(pattern: str) -> str:
     return output_pattern
 
 
+def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
+    # Convert pattern to einsum style pattern.
+    # For example, "one two three -> one three"
+    # would become: "ijk->ik".
+    pattern = _compatify_pattern_for_einsum(pattern)
+    return get_backend(tensors[0]).einsum(pattern, *tensors)

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -703,7 +703,9 @@ def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
 
     For a given pattern such as:
     ```python
+    >>> x, y, z = np.random.randn(3, 20, 20, 20)
     >>> output = einsum("a b c, c b d, a g k -> a b k", x, y, z)
+
     ```
     the following formula is computed:
     ```tex

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -755,9 +755,9 @@ def einsum(*tensors_and_pattern: List[Union[Tensor, str]]) -> Tensor:
     ```
 
     Parameters:
+        tensors: tensors of any supported library (numpy, tensorflow, pytorch, jax).
         pattern: string, einsum pattern, with commas
                  separating specifications for each tensor.
-        tensors: tensors of any supported library (numpy, tensorflow, pytorch, jax).
 
     Returns:
         Tensor of the same type as input, after processing with einsum.

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -636,9 +636,6 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
     lefts, right = pattern.split('->')
     lefts = lefts.split(',')
 
-    # Remove white space on both sides,
-    # so that both "a b, c" and "a b , c" are valid.
-    lefts = [left.strip() for left in lefts]
     lefts = [
         ParsedExpression(left, allow_underscore=True, allow_duplicates=True)
         for left in lefts

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -638,7 +638,7 @@ def _validate_einsum_axis_name(axis_name):
         raise RuntimeError("Encountered empty axis name in einsum.")
     if not isinstance(axis_name, str):
         raise RuntimeError("Axis name in einsum must be a string.")
-    if axis_name[0].isdigit()
+    if axis_name[0].isdigit():
         raise RuntimeError("Axis name in einsum must not start with a number.")
 
 
@@ -675,10 +675,10 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
             _validate_einsum_axis_name(raw_axis_name)
             axis_name = raw_axis_name[0]
             if axis_name not in axis_name_mapping:
-                axis_name_mapping[axis_name] = output_axis_names[i]
-                i += 1
                 if i >= len(output_axis_names):
                     raise RuntimeError("Too many axes in einsum.")
+                axis_name_mapping[axis_name] = output_axis_names[i]
+                i += 1
 
             left_pattern += axis_name_mapping[axis_name]
         left_patterns.append(left_pattern)

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -626,6 +626,21 @@ def asnumpy(tensor) -> 'numpy.ndarray':
     """
     return get_backend(tensor).to_numpy(tensor)
 
+def _validate_einsum_axis_name(axis_name):
+    if len(axis_name) == 0:
+        raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
+    if len(axis_name) > 1:
+        raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
+
+    axis_name = axis_name[0]
+
+    if len(axis_name) == 0:
+        raise RuntimeError("Encountered empty axis name in einsum.")
+    if not isinstance(axis_name, str):
+        raise RuntimeError("Axis name in einsum must be a string.")
+    if axis_name[0].isdigit()
+        raise RuntimeError("Axis name in einsum must not start with a number.")
+
 
 @functools.lru_cache(256)
 def _compactify_pattern_for_einsum(pattern: str) -> str:
@@ -656,13 +671,9 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
             if raw_axis_name == _ellipsis:
                 left_pattern += '...'
                 continue
-            elif len(raw_axis_name) == 0:
-                raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
-            elif len(raw_axis_name) > 1:
-                raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
-
-            axis_name = raw_axis_name[0]
             
+            _validate_einsum_axis_name(raw_axis_name)
+            axis_name = raw_axis_name[0]
             if axis_name not in axis_name_mapping:
                 axis_name_mapping[axis_name] = output_axis_names[i]
                 i += 1
@@ -678,11 +689,8 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
         if raw_axis_name == _ellipsis:
             output_pattern += '...'
             continue
-        elif len(raw_axis_name) == 0:
-            raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
-        elif len(raw_axis_name) > 1:
-            raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
 
+        _validate_einsum_axis_name(raw_axis_name)
         axis_name = raw_axis_name[0]
 
         if axis_name not in axis_name_mapping:

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -706,7 +706,6 @@ def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
     >>> filters = np.random.randn(16, 16, 30)
     >>> result = einsum("batch h w, h w channel -> batch channel",
     ...                 batched_images, filters) 
-
     >>> result.shape
     (128, 30)
 
@@ -718,6 +717,7 @@ def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
     ...                 weights, data)
     >>> result.shape
     (50, 30, 10)
+
     ```
 
     Parameters:

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -629,6 +629,10 @@ def asnumpy(tensor) -> 'numpy.ndarray':
 
 @functools.lru_cache(256)
 def _compactify_pattern_for_einsum(pattern: str) -> str:
+    if "->" not in pattern:
+        # numpy allows this, so make sure users
+        # don't accidentally do something like this.
+        raise ValueError("Einsum pattern must contain '->'.")
     lefts, right = pattern.split('->')
     lefts = lefts.split(',')
 

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -656,6 +656,8 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
             if raw_axis_name == _ellipsis:
                 left_pattern += '...'
                 continue
+            elif len(raw_axis_name) == 0:
+                raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
             elif len(raw_axis_name) > 1:
                 raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
 
@@ -676,6 +678,8 @@ def _compactify_pattern_for_einsum(pattern: str) -> str:
         if raw_axis_name == _ellipsis:
             output_pattern += '...'
             continue
+        elif len(raw_axis_name) == 0:
+            raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
         elif len(raw_axis_name) > 1:
             raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
 
@@ -697,8 +701,8 @@ def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
 
     Note that unlike other einops functions, here you must give
     the pattern before the tensor(s), rather than after.
-    Also, note that rearrange operations such as `"(batch chan) out"`
-    are not currently supported.
+    Also, note that rearrange operations such as `"(batch chan) out"`,
+    or singleton axes `()`, are not currently supported.
 
     Examples:
 

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -624,3 +624,67 @@ def asnumpy(tensor) -> 'numpy.ndarray':
         `numpy.ndarray`, converted to numpy
     """
     return get_backend(tensor).to_numpy(tensor)
+
+
+@functools.lru_cache(256)
+def _compatify_pattern_for_einsum(pattern: str) -> str:
+    lefts, right = pattern.split('->')
+    lefts = lefts.split(',')
+
+    # Remove white space on both sides,
+    # so that both "a b, c" and "a b , c" are valid.
+    lefts = [left.strip() for left in lefts]
+    
+    # Parse:
+    lefts = [ParsedExpression(left, allow_underscore=True) for left in lefts]
+    right = ParsedExpression(right, allow_underscore=True)
+
+    output_pattern = ""
+    # Create map using a hash table:
+
+    i = 0
+    # Start from a, and go up to Z
+    output_axis_names = string.ascii_letters
+    axis_name_mapping = {}
+
+    for index_left, left in enumerate(lefts):
+        if index_left > 0:
+            output_pattern += ","
+
+        for raw_axis_name in left.composition:
+
+            if raw_axis_name == _ellipsis:
+                output_pattern += '...'
+                continue
+            elif len(raw_axis_name) > 1:
+                raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
+
+            axis_name = raw_axis_name[0]
+            
+            if axis_name not in axis_name_mapping:
+                axis_name_mapping[axis_name] = output_axis_names[i]
+                i += 1
+                if i >= len(output_axis_names):
+                    raise RuntimeError("Too many axes in einsum.")
+
+            output_pattern += axis_name_mapping[axis_name]
+
+    output_pattern += "->"
+
+    for raw_axis_name in right.composition:
+        if raw_axis_name == _ellipsis:
+            output_pattern += '...'
+            continue
+        elif len(raw_axis_name) > 1:
+            raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
+
+        axis_name = raw_axis_name[0]
+
+        if axis_name not in axis_name_mapping:
+            raise RuntimeError("Unknown axis on right side of einsum.")
+        
+        output_pattern += axis_name_mapping[axis_name]
+
+    return output_pattern
+
+

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -628,7 +628,7 @@ def asnumpy(tensor) -> 'numpy.ndarray':
 
 
 @functools.lru_cache(256)
-def _compatify_pattern_for_einsum(pattern: str) -> str:
+def _compactify_pattern_for_einsum(pattern: str) -> str:
     lefts, right = pattern.split('->')
     lefts = lefts.split(',')
 
@@ -725,11 +725,11 @@ def einsum(pattern: str, *tensors: List[Tensor]) -> Tensor:
 
     Parameters:
         pattern: string, rearrangement pattern, with commas separating axes specified for each tensor.
-        tensors: tensors of any supported library (e.g. numpy.ndarray, tensorflow, pytorch, mxnet.ndarray).
+        tensors: tensors of any supported library (numpy, tensorflow, pytorch, jax).
 
     Returns:
         Tensor of the same type as input, after processing with einsum.
 
     """
-    pattern = _compatify_pattern_for_einsum(pattern)
+    pattern = _compactify_pattern_for_einsum(pattern)
     return get_backend(tensors[0]).einsum(pattern, *tensors)

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -1,5 +1,6 @@
 import functools
 import itertools
+import string
 import typing
 from collections import OrderedDict
 from typing import Tuple, List, Dict, Union, Callable, Optional, TypeVar

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -634,12 +634,12 @@ def _validate_einsum_axis_name(axis_name):
 
     axis_name = axis_name[0]
 
+    if isinstance(axis_name, AnonymousAxis):
+        raise NotImplementedError("Anonymous axes are not yet supported in einsum.")
     if len(axis_name) == 0:
         raise RuntimeError("Encountered empty axis name in einsum.")
     if not isinstance(axis_name, str):
         raise RuntimeError("Axis name in einsum must be a string.")
-    if axis_name[0].isdigit():
-        raise RuntimeError("Axis name in einsum must not start with a number.")
 
 
 @functools.lru_cache(256)

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -763,6 +763,11 @@ def einsum(*tensors_and_pattern: List[Union[Tensor, str]]) -> Tensor:
         Tensor of the same type as input, after processing with einsum.
 
     """
+    if len(tensors_and_pattern) <= 1:
+        raise ValueError(
+            "`einops.einsum` takes at minimum two arguments: the tensors,"
+            " followed by the pattern."
+        )
     pattern = tensors_and_pattern[-1]
     if not isinstance(pattern, str):
         raise ValueError(

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -637,7 +637,10 @@ def _compatify_pattern_for_einsum(pattern: str) -> str:
     lefts = [left.strip() for left in lefts]
     
     # Parse:
-    lefts = [ParsedExpression(left, allow_underscore=True) for left in lefts]
+    lefts = [
+        ParsedExpression(left, allow_underscore=True, allow_duplicates=True)
+        for left in lefts
+    ]
     right = ParsedExpression(right, allow_underscore=True)
 
     output_pattern = ""

--- a/einops/parsing.py
+++ b/einops/parsing.py
@@ -26,7 +26,8 @@ class ParsedExpression:
     non-mutable structure that contains information about one side of expression (e.g. 'b c (h w)')
     and keeps some information important for downstream
     """
-    def __init__(self, expression, *, allow_underscore: bool = False):
+    def __init__(self, expression, *, allow_underscore: bool = False,
+                 allow_duplicates: bool = False):
         self.has_ellipsis: bool = False
         self.has_ellipsis_parenthesized: Optional[bool] = None
         self.identifiers: Set[str] = set()
@@ -48,7 +49,7 @@ class ParsedExpression:
         def add_axis_name(x):
             if x is not None:
                 if x in self.identifiers:
-                    if not (allow_underscore and x == "_"):
+                    if not (allow_underscore and x == "_") and not allow_duplicates:
                         raise EinopsError('Indexing expression contains duplicate dimension "{}"'.format(x))
                 if x == _ellipsis:
                     self.identifiers.add(_ellipsis)

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -2,7 +2,7 @@ from venv import create
 from . import collect_test_backends
 from einops.einops import _compactify_pattern_for_einsum, einsum, EinopsError
 import numpy as np
-from nose.tools import assert_raises, assert_raises_regex
+from nose.tools import assert_raises_regex
 import string
 
 

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -2,7 +2,7 @@ from venv import create
 from . import collect_test_backends
 from einops.einops import _compactify_pattern_for_einsum, einsum
 import numpy as np
-from nose.tools import assert_raises
+from nose.tools import assert_raises, assert_raises_regex
 import string
 
 
@@ -269,20 +269,20 @@ def test_functional_errors():
     create_tensor = lambda *shape: rstate.uniform(size=shape).astype('float32')
 
     # raise NotImplementedError("Singleton () axes are not yet supported in einsum.")
-    with assert_raises(NotImplementedError):
+    with assert_raises_regex(NotImplementedError, "^Singleton"):
         einsum(
             create_tensor(5, 1),
             "i () -> i",
         )
 
     # raise NotImplementedError("Shape rearrangement is not yet supported in einsum.")
-    with assert_raises(NotImplementedError):
+    with assert_raises_regex(NotImplementedError, "^Shape rearrangement"):
         einsum(
             create_tensor(5, 1),
             "a b -> (a b)",
         )
 
-    with assert_raises(NotImplementedError):
+    with assert_raises_regex(NotImplementedError, "^Shape rearrangement"):
         einsum(
             create_tensor(10, 1),
             "(a b) -> a b",
@@ -300,21 +300,21 @@ def test_functional_errors():
         )
 
     # raise ValueError("Einsum pattern must contain '->'.")
-    with assert_raises(ValueError):
+    with assert_raises_regex(ValueError, "^Einsum pattern"):
         einsum(
             create_tensor(5, 3, 2),
             "i j k",
         )
 
     # raise RuntimeError("Too many axes in einsum.")
-    with assert_raises(RuntimeError):
+    with assert_raises_regex(RuntimeError, "^Too many axes"):
         einsum(
             create_tensor(1),
             " ".join(string.ascii_letters) + " extra ->",
         )
 
     # raise RuntimeError("Unknown axis on right side of einsum.")
-    with assert_raises(RuntimeError):
+    with assert_raises_regex(RuntimeError, "^Unknown axis"):
         einsum(
             create_tensor(5, 1),
             "i j -> k",
@@ -324,7 +324,7 @@ def test_functional_errors():
     # "The last argument passed to `einops.einsum` must be a string,"
     # " representing the einsum pattern."
     # )
-    with assert_raises(ValueError):
+    with assert_raises_regex(ValueError, "^The last argument"):
         einsum(
             "i j k -> i",
             create_tensor(5, 4, 3),
@@ -334,14 +334,16 @@ def test_functional_errors():
     #     "`einops.einsum` takes at minimum two arguments: the tensors,"
     #     " followed by the pattern."
     # )
-    with assert_raises(ValueError):
+    with assert_raises_regex(ValueError, "^`einops.einsum` takes"):
         einsum(
             "i j k -> i",
         )
-    with assert_raises(ValueError):
+    with assert_raises_regex(ValueError, "^`einops.einsum` takes"):
         einsum(
             create_tensor(5, 1),
         )
+
+    # TODO: Include check for giving normal einsum pattern rather than einops.
 
 # mxnet/gluon do not support einsum without changing to numpy. which doesn't work with the rest
 # in future, after gluon migrated to a new codebase, all testing code will be moved to a new setup

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -119,8 +119,10 @@ def test_layer():
 
 def test_functional():
     # Functional tests:
+    valid_backends = ['tensorflow', 'torch', 'jax', 'numpy',
+                      'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
     for backend in collect_test_backends():
-        if backend.framework_name in ['tensorflow', 'torch', 'jax', 'numpy']:
+        if backend.framework_name in valid_backends:
             for args, true_pattern, in_shapes, out_shape in test_functional_cases:
                 print(f"Running '{args.args[0]}' for {backend.framework_name}")
                 predicted_pattern = args(_compactify_pattern_for_einsum)

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -320,6 +320,29 @@ def test_functional_errors():
             "i j -> k",
         )
 
+    # raise ValueError(
+    # "The last argument passed to `einops.einsum` must be a string,"
+    # " representing the einsum pattern."
+    # )
+    with assert_raises(ValueError):
+        einsum(
+            "i j k -> i",
+            create_tensor(5, 4, 3),
+        )
+
+    # raise ValueError(
+    #     "`einops.einsum` takes at minimum two arguments: the tensors,"
+    #     " followed by the pattern."
+    # )
+    with assert_raises(ValueError):
+        einsum(
+            "i j k -> i",
+        )
+    with assert_raises(ValueError):
+        einsum(
+            create_tensor(5, 1),
+        )
+
 # mxnet/gluon do not support einsum without changing to numpy. which doesn't work with the rest
 # in future, after gluon migrated to a new codebase, all testing code will be moved to a new setup
 # def test_gluon():

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -176,8 +176,7 @@ def test_layer():
 
 
 valid_backends_functional = ['tensorflow', 'torch', 'jax', 'numpy',
-                             'chainer', 'oneflow', 'cupy', 'tensorflow.keras',
-                             'mxnet.symbol', 'mxnet.ndarray']
+                             'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
 
 def test_functional():
     # Functional tests:

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -1,5 +1,5 @@
 from . import collect_test_backends
-from einops.einops import _compatify_pattern_for_einsum
+from einops.einops import _compactify_pattern_for_einsum
 import numpy as np
 
 
@@ -123,7 +123,7 @@ def test_functional():
         if backend.framework_name in ['tensorflow', 'torch', 'jax', 'numpy']:
             for args, true_pattern, in_shapes, out_shape in test_functional_cases:
                 print(f"Running '{args.args[0]}' for {backend.framework_name}")
-                predicted_pattern = args(_compatify_pattern_for_einsum)
+                predicted_pattern = args(_compactify_pattern_for_einsum)
                 assert predicted_pattern == true_pattern
                 in_arrays = [
                     np.random.uniform(size=shape).astype('float32')

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -1,6 +1,6 @@
 from venv import create
 from . import collect_test_backends
-from einops.einops import _compactify_pattern_for_einsum, einsum
+from einops.einops import _compactify_pattern_for_einsum, einsum, EinopsError
 import numpy as np
 from nose.tools import assert_raises, assert_raises_regex
 import string
@@ -292,11 +292,18 @@ def test_functional_errors():
     # raise RuntimeError("Axis name in einsum must be a string.")
     # ^ Not tested, these are just a failsafe in case an unexpected error occurs.
 
-    # raise RuntimeError("Axis name in einsum must not start with a number.")
-    with assert_raises(RuntimeError):
+    # raise NotImplementedError("Anonymous axes are not yet supported in einsum.")
+    with assert_raises_regex(NotImplementedError, "^Anonymous axes"):
         einsum(
             create_tensor(5, 1),
-            "i 1j -> i",
+            "i 2 -> i",
+        )
+
+    # ParsedExpression error:
+    with assert_raises_regex(EinopsError, "^Invalid axis identifier"):
+        einsum(
+            create_tensor(5, 1),
+            "i 2j -> i",
         )
 
     # raise ValueError("Einsum pattern must contain '->'.")

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -239,7 +239,10 @@ def test_functional_symbolic():
                 predicted_out_symbol,
                 list(zip(in_syms, in_data)),
             )
-            assert predicted_out_data.shape == out_shape
+            if predicted_out_data.shape != out_shape:
+                raise ValueError(
+                    f"Expected output shape {out_shape} but got {predicted_out_data.shape}"
+                )
             assert np.testing.assert_array_almost_equal(predicted_out_data,
                                                         expected_out_data,
                                                         decimal=5)

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -94,11 +94,69 @@ test_functional_cases = [
         (),
     ),
     (
+        # Too many spaces in string:
+        " one  two  ,  three four->two  four  ",
+        "ab,cd->bd",
+        ((2, 3), (4, 5)),
+        (3, 5),
+    ),
+    # The following tests were inspired by numpy's einsum tests
+    # https://github.com/numpy/numpy/blob/v1.23.0/numpy/core/tests/test_einsum.py
+    (
         # Trace with other indices
         "i middle i -> middle",
         "aba->b",
         ((5, 10, 5),),
         (10,),
+    ),
+    (
+        # Ellipsis in the middle:
+        "i ... i -> ...",
+        "a...a->...",
+        ((5, 3, 2, 1, 4, 5),),
+        (3, 2, 1, 4),
+    ),
+    (
+        # Product of first and last axes:
+        "i ... i -> i ...",
+        "a...a->a...",
+        ((5, 3, 2, 1, 4, 5),),
+        (5, 3, 2, 1, 4),
+    ),
+    (
+        # Triple diagonal
+        "one one one -> one",
+        "aaa->a",
+        ((5, 5, 5),),
+        (5,),
+    ),
+    (
+        # Axis swap:
+        "i j k -> j i k",
+        "abc->bac",
+        ((1, 2, 3),),
+        (2, 1, 3),
+    ),
+    (
+        # Identity:
+        "... -> ...",
+        "...->...",
+        ((5, 4, 3, 2, 1),),
+        (5, 4, 3, 2, 1),
+    ),
+    (
+        # Elementwise product of three tensors
+        "..., ..., ... -> ...",
+        "...,...,...->...",
+        ((3, 2), (3, 2), (3, 2)),
+        (3, 2),
+    ),
+    (
+        # Basic summation:
+        "index ->",
+        "a->",
+        ((10,)),
+        (()),
     ),
 ]
 

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -125,22 +125,36 @@ def test_functional():
         if backend.framework_name in valid_backends:
             for args, true_pattern, in_shapes, out_shape in test_functional_cases:
                 print(f"Running '{args.args[0]}' for {backend.framework_name}")
+                
+                # Create pattern:
                 predicted_pattern = args(_compactify_pattern_for_einsum)
                 assert predicted_pattern == true_pattern
+
+                # Generate example data:
+                rstate = np.random.RandomState(0)
                 in_arrays = [
-                    np.random.uniform(size=shape).astype('float32')
+                    rstate.uniform(size=shape).astype('float32')
                     for shape in in_shapes
                 ]
                 in_arrays_framework = [
-                    backend.from_numpy(array)
-                    for array in in_arrays
+                    backend.from_numpy(array) for array in in_arrays
                 ]
+                
+                # Actually run einsum:
                 out_array = backend.einsum(predicted_pattern, *in_arrays_framework)
+                
+                # Check shape:
                 if out_array.shape != out_shape:
                     raise ValueError(
                         f"Expected output shape {out_shape} but got {out_array.shape}"
                     )
-                # assert out_array.shape == out_shape
+
+                # Check values:
+                true_out_array = np.einsum(true_pattern, *in_arrays)
+                predicted_out_array = backend.to_numpy(out_array)
+                np.testing.assert_array_almost_equal(predicted_out_array,
+                                                     true_out_array,
+                                                     decimal=5)
 
 
 # mxnet/gluon do not support einsum without changing to numpy. which doesn't work with the rest

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -1,4 +1,5 @@
 from . import collect_test_backends
+from einops.einops import _compatify_pattern_for_einsum
 import numpy as np
 
 
@@ -40,6 +41,53 @@ test_layer_cases = [
 ]
 
 
+# Each of the form:
+# (Arguments, true_einsum_pattern, in_shapes, out_shape)
+test_functional_cases = [
+    (
+        # Basic:
+        Arguments("b c h w, b w -> b h"),
+        "abcd,ad->ac",
+        ((2, 3, 4, 5), (2, 5)),
+        (2, 4),
+    ),
+    (
+        # Three tensors:
+        Arguments("b c h w, b w, b c -> b h"),
+        "abcd,ad,ab->ac",
+        ((2, 3, 40, 5), (2, 5), (2, 3)),
+        (2, 40),
+    ),
+    (
+        # Ellipsis, and full names:
+        Arguments("... one two three, three four five -> ... two five"),
+        "...abc,cde->...be",
+        ((32, 5, 2, 3, 4), (4, 5, 6)),
+        (32, 5, 3, 6),
+    ),
+    (
+        # Ellipsis at the end:
+        Arguments("one two three ..., three four five -> two five ..."),
+        "abc...,cde->be...",
+        ((2, 3, 4, 32, 5), (4, 5, 6)),
+        (3, 6, 32, 5),
+    ),
+    (
+        # Ellipsis on multiple tensors:
+        Arguments("... one two three, ... three four five -> ... two five"),
+        "...abc,...cde->...be",
+        ((32, 5, 2, 3, 4), (32, 5, 4, 5, 6)),
+        (32, 5, 3, 6),
+    ),
+    (
+        # One tensor, and underscores:
+        Arguments("first_tensor second_tensor -> first_tensor"),
+        "ab->a",
+        ((5, 4),),
+        (5,),
+    )
+]
+
 
 def test_layer():
     for backend in collect_test_backends(layers=True, symbolic=False):
@@ -53,6 +101,27 @@ def test_layer():
                 output_framework = layer(input_framework)
                 output = backend.to_numpy(output_framework)
                 assert output.shape == out_shape
+
+
+def test_functional():
+    # Functional tests:
+    for backend in collect_test_backends():
+        if backend.framework_name in ['tensorflow', 'torch', 'jax', 'numpy']:
+            for args, true_pattern, in_shapes, out_shape in test_functional_cases:
+                print(f"Running '{args.args[0]}' for {backend.framework_name}")
+                predicted_pattern = args(_compatify_pattern_for_einsum)
+                assert predicted_pattern == true_pattern
+                in_arrays = [
+                    np.random.uniform(size=shape).astype('float32')
+                    for shape in in_shapes
+                ]
+                in_arrays_framework = [
+                    backend.from_numpy(array)
+                    for array in in_arrays
+                ]
+                out_array = backend.einsum(predicted_pattern, *in_arrays_framework)
+                assert out_array.shape == out_shape
+
 
 # mxnet/gluon do not support einsum without changing to numpy. which doesn't work with the rest
 # in future, after gluon migrated to a new codebase, all testing code will be moved to a new setup

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -11,7 +11,7 @@ class Arguments:
         return function(*self.args, **self.kwargs)
 
 
-test_cases = [
+test_layer_cases = [
     (
         Arguments('b c_in h w -> w c_out h b', 'c_in c_out', bias_shape=None, c_out=13, c_in=12),
         (2, 12, 3, 4),
@@ -40,11 +40,12 @@ test_cases = [
 ]
 
 
-def test_all():
+
+def test_layer():
     for backend in collect_test_backends(layers=True, symbolic=False):
         if backend.framework_name in ['tensorflow', 'torch', 'chainer', 'oneflow']:
             layer_type = backend.layers().EinMix
-            for args, in_shape, out_shape in test_cases:
+            for args, in_shape, out_shape in test_layer_cases:
                 layer = args(layer_type)
                 print('Running', layer.einsum_pattern, 'for', backend.framework_name)
                 input = np.random.uniform(size=in_shape).astype('float32')

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -85,7 +85,21 @@ test_functional_cases = [
         "ab->a",
         ((5, 4),),
         (5,),
-    )
+    ),
+    (
+        # Trace (repeated index)
+        Arguments("i i -> "),
+        "aa->",
+        ((5, 5),),
+        (),
+    ),
+    (
+        # Trace with other indices
+        Arguments("i middle i -> middle"),
+        "aba->b",
+        ((5, 10, 5),),
+        (10,),
+    ),
 ]
 
 
@@ -120,7 +134,11 @@ def test_functional():
                     for array in in_arrays
                 ]
                 out_array = backend.einsum(predicted_pattern, *in_arrays_framework)
-                assert out_array.shape == out_shape
+                if out_array.shape != out_shape:
+                    raise ValueError(
+                        f"Expected output shape {out_shape} but got {out_array.shape}"
+                    )
+                # assert out_array.shape == out_shape
 
 
 # mxnet/gluon do not support einsum without changing to numpy. which doesn't work with the rest

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -46,56 +46,56 @@ test_layer_cases = [
 test_functional_cases = [
     (
         # Basic:
-        Arguments("b c h w, b w -> b h"),
+        "b c h w, b w -> b h",
         "abcd,ad->ac",
         ((2, 3, 4, 5), (2, 5)),
         (2, 4),
     ),
     (
         # Three tensors:
-        Arguments("b c h w, b w, b c -> b h"),
+        "b c h w, b w, b c -> b h",
         "abcd,ad,ab->ac",
         ((2, 3, 40, 5), (2, 5), (2, 3)),
         (2, 40),
     ),
     (
         # Ellipsis, and full names:
-        Arguments("... one two three, three four five -> ... two five"),
+        "... one two three, three four five -> ... two five",
         "...abc,cde->...be",
         ((32, 5, 2, 3, 4), (4, 5, 6)),
         (32, 5, 3, 6),
     ),
     (
         # Ellipsis at the end:
-        Arguments("one two three ..., three four five -> two five ..."),
+        "one two three ..., three four five -> two five ...",
         "abc...,cde->be...",
         ((2, 3, 4, 32, 5), (4, 5, 6)),
         (3, 6, 32, 5),
     ),
     (
         # Ellipsis on multiple tensors:
-        Arguments("... one two three, ... three four five -> ... two five"),
+        "... one two three, ... three four five -> ... two five",
         "...abc,...cde->...be",
         ((32, 5, 2, 3, 4), (32, 5, 4, 5, 6)),
         (32, 5, 3, 6),
     ),
     (
         # One tensor, and underscores:
-        Arguments("first_tensor second_tensor -> first_tensor"),
+        "first_tensor second_tensor -> first_tensor",
         "ab->a",
         ((5, 4),),
         (5,),
     ),
     (
         # Trace (repeated index)
-        Arguments("i i -> "),
+        "i i -> ",
         "aa->",
         ((5, 5),),
         (),
     ),
     (
         # Trace with other indices
-        Arguments("i middle i -> middle"),
+        "i middle i -> middle",
         "aba->b",
         ((5, 10, 5),),
         (10,),
@@ -123,11 +123,11 @@ def test_functional():
                       'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
     for backend in collect_test_backends():
         if backend.framework_name in valid_backends:
-            for args, true_pattern, in_shapes, out_shape in test_functional_cases:
-                print(f"Running '{args.args[0]}' for {backend.framework_name}")
+            for einops_pattern, true_pattern, in_shapes, out_shape in test_functional_cases:
+                print(f"Running '{einops_pattern}' for {backend.framework_name}")
                 
                 # Create pattern:
-                predicted_pattern = args(_compactify_pattern_for_einsum)
+                predicted_pattern = _compactify_pattern_for_einsum(einops_pattern)
                 assert predicted_pattern == true_pattern
 
                 # Generate example data:

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -175,15 +175,14 @@ def test_layer():
                 assert output.shape == out_shape
 
 
+valid_backends_functional = ['tensorflow', 'torch', 'jax', 'numpy',
+                             'chainer', 'oneflow', 'cupy', 'tensorflow.keras',
+                             'mxnet.symbol', 'mxnet.ndarray']
+
 def test_functional():
     # Functional tests:
-    valid_backends = ['tensorflow', 'torch', 'jax', 'numpy',
-                      'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
-    backends = collect_test_backends() + collect_test_backends(symbolic=True)
-    backends = set(backends)
-
-    for backend in backends:
-        if backend.framework_name in valid_backends:
+    for backend in collect_test_backends():
+        if backend.framework_name in valid_backends_functional:
             for einops_pattern, true_pattern, in_shapes, out_shape in test_functional_cases:
                 print(f"Running '{einops_pattern}' for {backend.framework_name}")
                 

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -179,7 +179,10 @@ def test_functional():
     # Functional tests:
     valid_backends = ['tensorflow', 'torch', 'jax', 'numpy',
                       'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
-    for backend in collect_test_backends():
+    backends = collect_test_backends() + collect_test_backends(symbolic=True)
+    backends = set(backends)
+
+    for backend in backends:
         if backend.framework_name in valid_backends:
             for einops_pattern, true_pattern, in_shapes, out_shape in test_functional_cases:
                 print(f"Running '{einops_pattern}' for {backend.framework_name}")


### PR DESCRIPTION
This creates the functional einsum function as requested on #73. CC @arogozhnikov @cgarciae 

The current implementation simply parses the string and converts it to `einsum` notation by mapping axis names to single characters (I use `string.ascii_letters`, starting from `a, b, c` etc).

Currently, it has the following features:

- Supports the backends: tensorflow, numpy, jax, pytorch, chainer, oneflow, keras, cupy.
- Allows for an arbitrary number of tensors passed.
- Allows ellipsis specification, including for multiple tensors, so long as it is provided on both the left and the right of the `->`.

It does not currently support
- Reshape operations, such as `"(batch channel) feature, feature -> batch channel"`.
- Custom reduction operations.

These could be added later if desired. Some backends do not support custom reductions in their einsum implementations so it will be a bit more work.

I also added a docstring and some unittests (in `tests/test_einsum.py`). 

Here are some examples of use, with the numpy backend:
```python
# Filter a set of images:
>>> batched_images = np.random.randn(128, 16, 16)
>>> filters = np.random.randn(16, 16, 30)
>>> result = einsum(batched_images, filters,
...                 "batch h w, h w channel -> batch channel") 

>>> result.shape
(128, 30)

# Matrix multiplication, with an unknown input shape:
>>> batch_shape = (50, 30)
>>> data = np.random.randn(*batch_shape, 20)
>>> weights = np.random.randn(10, 20)
>>> result = einsum(weights, data, 
...                 "out_dim in_dim, ... in_dim -> ... out_dim")
>>> result.shape
(50, 30, 10)
```

Note that the number of spaces next to the comma above are arbitrary, you could do either `"in_dim, ..."` or `"in_dim , ..."` - both will work.

Eager to hear feedback on this!

Cheers,
Miles

---

**Edit 1**: Got working for repeat indices on one side (as used in, e.g., trace).
**Edit 2**: Added support for chainer, oneflow, cupy, tensorflow.keras.
**Edit 3**: Added many more tests, some mirroring those used in the np.einsum tests.
**Edit 4**: More and more unit tests. 
**Edit 5**: Tweaked the syntax to have tensors first, pattern second. Adapted tests, and added new validation for order of arguments.