### PR TITLE
corrected spelling mistake: einsops -> einops

### DIFF
--- a/docs/2-einops-for-deep-learning.ipynb
+++ b/docs/2-einops-for-deep-learning.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "- working with deep learning packages\n",
     "- important cases for deep learning models\n",
-    "- `einsops.asnumpy` and `einops.layers`"
+    "- `einops.asnumpy` and `einops.layers`"
    ]
   },
   {
@@ -215,7 +215,6 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -333,7 +332,6 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -421,7 +419,6 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -457,7 +454,6 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -556,7 +552,6 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -603,7 +598,6 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -669,7 +663,6 @@
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -705,7 +698,6 @@
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -790,7 +782,6 @@
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -874,7 +865,6 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -1024,7 +1014,6 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     },
@@ -1210,7 +1199,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Correcting a small typo in `2-einops-for-deep-learning.ipynb`