### PR TITLE
Add paddle backend, rewrite testing infrastructure

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.8', '3.10']
         # currently there is conflict between tf, oneflow and paddle in protobuf versions.
         # cupy is not tested because it demands gpu
-        frameworks: ['numpy pytorch tensorflow jax flax oneflow', 'numpy paddle chainer']
+        frameworks: ['numpy pytorch tensorflow jax oneflow', 'numpy paddle chainer']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.8', '3.10']
         # currently there is conflict between tf and paddle in protobuf versions.
         # cupy is not tested because it demands gpu
-        frameworks: ['numpy pytorch tensorflow jax chainer', 'numpy paddle oneflow']
+        frameworks: ['numpy pytorch tensorflow jax chainer', 'numpy paddle']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.9]
+        python-version: [3.8, 3.10]
+        # currently there is conflict between tf and paddle in protobuf versions.
+        # cupy is not tested because it demands gpu
+        frameworks: ['numpy pytorch tensorflow jax chainer', 'numpy paddle oneflow']
 
     steps:
       - uses: actions/checkout@v3
@@ -18,4 +21,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
         run: |
-          python test.py
+          python test.py ${{ matrix.frameworks }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ['3.8', '3.10']
         # currently there is conflict between tf and paddle in protobuf versions.
         # cupy is not tested because it demands gpu
-        frameworks: ['numpy pytorch tensorflow jax chainer', 'numpy paddle']
+        frameworks: ['numpy pytorch tensorflow jax flax', 'numpy paddle chainer']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.10']
-        # currently there is conflict between tf and paddle in protobuf versions.
+        # currently there is conflict between tf, oneflow and paddle in protobuf versions.
         # cupy is not tested because it demands gpu
-        frameworks: ['numpy pytorch tensorflow jax flax', 'numpy paddle chainer']
+        frameworks: ['numpy pytorch tensorflow jax flax oneflow', 'numpy paddle chainer']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.10]
+        python-version: ['3.8', '3.10']
         # currently there is conflict between tf and paddle in protobuf versions.
         # cupy is not tested because it demands gpu
         frameworks: ['numpy pytorch tensorflow jax chainer', 'numpy paddle oneflow']

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -624,7 +624,7 @@ class PaddleBackend(AbstractBackend):
         self.paddle = paddle
 
     def is_appropriate_type(self, tensor):
-        return isinstance(tensor, self.paddle.Tensor, self.paddle.static.Variable)
+        return isinstance(tensor, (self.paddle.Tensor, self.paddle.static.Variable))
 
     def from_numpy(self, x):
         tensor = self.paddle.to_tensor(x)
@@ -648,7 +648,7 @@ class PaddleBackend(AbstractBackend):
         return x.transpose(axes)
 
     def add_axes(self, x, n_axes, pos2len):
-        repeats = [1] * n_axes
+        repeats = [-1] * n_axes
         for axis_position, axis_length in pos2len.items():
             x = self.add_axis(x, axis_position)
             repeats[axis_position] = axis_length

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -614,3 +614,70 @@ class OneFlowBackend(AbstractBackend):
 
     def einsum(self, pattern, *x):
         return self.flow.einsum(pattern, *x)
+
+
+class PaddleBackend(AbstractBackend):
+    framework_name = "paddle"
+
+    def __init__(self):
+        import paddle
+        self.paddle = paddle
+
+    def is_appropriate_type(self, tensor):
+        return isinstance(tensor, self.paddle.Tensor, self.paddle.static.Variable)
+
+    def from_numpy(self, x):
+        tensor = self.paddle.to_tensor(x)
+        tensor.stop_gradient = False
+        return tensor
+
+    def to_numpy(self, x):
+        return x.detach().numpy()
+
+    def arange(self, start, stop):
+        return self.paddle.arange(start, stop, dtype=self.paddle.int64)
+
+    def reduce(self, x, operation, axes):
+        # TODO: Support the reduce operation to output a 0D Tensor
+        if len(axes) == x.ndim:
+            return super().reduce(x, operation, axes).squeeze(0)
+        else:
+            return super().reduce(x, operation, axes)
+
+    def transpose(self, x, axes):
+        return x.transpose(axes)
+
+    def add_axes(self, x, n_axes, pos2len):
+        repeats = [1] * n_axes
+        for axis_position, axis_length in pos2len.items():
+            x = self.add_axis(x, axis_position)
+            repeats[axis_position] = axis_length
+        return x.expand(repeats)
+
+    def stack_on_zeroth_dimension(self, tensors: list):
+        return self.paddle.stack(tensors)
+
+    def reshape(self, x, shape):
+        return x.reshape(shape)
+
+    def tile(self, x, repeats):
+        return x.tile(repeats)
+
+    def concat(self, tensors, axis: int):
+        return self.paddle.concat(tensors, axis=axis)
+
+    def add_axis(self, x, new_position):
+        return x.unsqueeze(new_position)
+
+    def is_float_type(self, x):
+        return x.dtype in [self.paddle.float16, self.paddle.float32, self.paddle.float64]
+
+    def layers(self):
+        from .layers import paddle
+        return paddle
+
+    def einsum(self, pattern, *x):
+        return self.paddle.einsum(pattern, *x)
+
+    def shape(self, x):
+        return tuple(x.shape)

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -553,7 +553,6 @@ class OneFlowBackend(AbstractBackend):
     def __init__(self):
         import oneflow as flow
         self.flow = flow
-        print("using oneflow")
 
     def is_appropriate_type(self, tensor):
         return isinstance(tensor, self.flow.Tensor)

--- a/einops/layers/paddle.py
+++ b/einops/layers/paddle.py
@@ -1,0 +1,59 @@
+from typing import Optional, Dict, cast
+
+import paddle
+
+from . import RearrangeMixin, ReduceMixin
+from ._einmix import _EinmixMixin
+
+__author__ = 'PaddlePaddle'
+
+
+class Rearrange(RearrangeMixin, paddle.nn.Layer):
+    def forward(self, input):
+        return self._apply_recipe(input)
+
+
+class Reduce(ReduceMixin, paddle.nn.Layer):
+    def forward(self, input):
+        return self._apply_recipe(input)
+
+
+class EinMix(_EinmixMixin, paddle.nn.Layer):
+    def _create_parameters(self, weight_shape, weight_bound, bias_shape, bias_bound):
+        self.weight = self.create_parameter(
+            weight_shape, 
+            default_initializer=paddle.nn.initializer.Uniform(-weight_bound, weight_bound)
+        )
+
+        if bias_shape is not None:
+            self.bias = self.create_parameter(
+                bias_shape,
+                default_initializer=paddle.nn.initializer.Uniform(-bias_bound, bias_bound)
+            )
+        else:
+            self.bias = None
+
+    def _create_rearrange_layers(self,
+                                 pre_reshape_pattern: Optional[str],
+                                 pre_reshape_lengths: Optional[Dict],
+                                 post_reshape_pattern: Optional[str],
+                                 post_reshape_lengths: Optional[Dict],
+                                 ):
+        self.pre_rearrange = None
+        if pre_reshape_pattern is not None:
+            self.pre_rearrange = Rearrange(pre_reshape_pattern, **cast(dict, pre_reshape_lengths))
+
+        self.post_rearrange = None
+        if post_reshape_pattern is not None:
+            self.post_rearrange = Rearrange(post_reshape_pattern, **cast(dict, post_reshape_lengths))
+
+    def forward(self, input):
+        if self.pre_rearrange is not None:
+            input = self.pre_rearrange(input)
+        
+        result = paddle.einsum(self.einsum_pattern, input, self.weight)
+        if self.bias is not None:
+            result += self.bias
+        if self.post_rearrange is not None:
+            result = self.post_rearrange(result)
+        return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,7 @@ filterwarnings = [
     "ignore:Call to deprecated create function FileDescriptor",
     "ignore:Call to deprecated create function OneofDescriptor",
 ]
+
+[tool.black]
+line-length = 120
+target-version = ['py311']

--- a/test.py
+++ b/test.py
@@ -36,7 +36,8 @@ def main():
     framework_name2installation = {
         "numpy": ["numpy"],
         "pytorch": ["torch"],
-        "jax": ["jax", "jaxlib", "flax"],
+        "jax": ["jax", "jaxlib"],
+        "flax": ["flax", "jax", "jaxlib"],
         "tensorflow": ["tensorflow"],
         "chainer": ["chainer"],
         "cupy": ["cupy"],

--- a/test.py
+++ b/test.py
@@ -36,8 +36,7 @@ def main():
     framework_name2installation = {
         "numpy": ["numpy"],
         "torch": ["torch"],
-        "jax": ["jax", "jaxlib"],
-        "flax": ["flax", "jax", "jaxlib"],
+        "jax": ["jax", "jaxlib", "flax"],
         "tensorflow": ["tensorflow"],
         "chainer": ["chainer"],
         "cupy": ["cupy"],

--- a/test.py
+++ b/test.py
@@ -50,6 +50,7 @@ dependencies = [
     'parameterized',
     'pillow',
     'pytest',
+    'paddlepaddle'
 ]
 
 assert 0 == run('pip install {} --progress-bar off'.format(' '.join(dependencies)))

--- a/test.py
+++ b/test.py
@@ -1,83 +1,100 @@
 """
-Usage: python test.py
+Usage: python test.py <frameworks>
+
 1. Installs part of dependencies (make sure `which pip` points to correct location)
 2. Installs current version of einops in editable mode
 3. Runs the tests
 """
 
 import os
+import shutil
 import sys
 from subprocess import Popen, PIPE
 from pathlib import Path
 
-__author__ = 'Alex Rogozhnikov'
+__author__ = "Alex Rogozhnikov"
 
 
 def run(cmd, **env):
     # keeps printing output when testing
-    cmd = cmd.split(' ') if isinstance(cmd, str) else cmd
+    cmd = cmd.split(" ") if isinstance(cmd, str) else cmd
     p = Popen(cmd, cwd=str(Path(__file__).parent), env={**os.environ, **env})
     p.communicate()
     return p.returncode
 
 
 # check we have nvidia-smi
-import shutil
 have_cuda = False
-if shutil.which('nvidia-smi') is not None:
-    output, _ = Popen('nvidia-smi'.split(' '), stdout=PIPE).communicate()
-    if b'failed because' not in output:
+if shutil.which("nvidia-smi") is not None:
+    output, _ = Popen("nvidia-smi".split(" "), stdout=PIPE).communicate()
+    if b"failed because" not in output:
         have_cuda = True
 
-# install cupy. It can't be installed without cuda available (with compilers).
-skip_cupy = not have_cuda
-if not skip_cupy:
-    return_code = run('pip install cupy --pre --progress-bar off')
+
+def main():
+    _executable, *frameworks = sys.argv
+    framework_name2installation = {
+        "numpy": ["numpy"],
+        "pytorch": ["torch"],
+        "jax": ["jax", "jaxlib", "flax"],
+        "tensorflow": ["tensorflow"],
+        "chainer": ["chainer"],
+        "cupy": ["cupy"],
+        "paddle": ["paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html"],
+        "oneflow": ["oneflow==0.7.0+cpu -f https://release.oneflow.info"],
+    }
+
+    usage = f"""
+    Usage:   python test.py <frameworks>
+    Example: python test.py numpy pytorch
+
+    Available frameworks: {list(framework_name2installation)}
+    """
+    if len(frameworks) == 0:
+        print(usage)
+        return
+    else:
+        synonyms = {
+            "tf": "tensorflow",
+            "torch": "pytorch",
+            "paddlepaddle": "paddle",
+        }
+        frameworks = [synonyms.get(f, f) for f in frameworks]
+        wrong_frameworks = [f for f in frameworks if f not in framework_name2installation]
+        if wrong_frameworks:
+            print(usage)
+            raise RuntimeError(f"Unrecognized frameworks: {wrong_frameworks}")
+
+    other_dependencies = [
+        "nbformat",
+        "nbconvert",
+        "jupyter",
+        "parameterized",
+        "pillow",
+        "pytest",
+    ]
+    for framework in frameworks:
+        print(f"Installing {framework}")
+        pip_instructions = framework_name2installation[framework]
+        assert 0 == run("pip install {} --progress-bar off".format(" ".join(pip_instructions)))
+
+    print("Install testing infra")
+    assert 0 == run("pip install {} --progress-bar off".format(" ".join(other_dependencies)))
+
+    # install einops
+    assert 0 == run("pip install -e .")
+
+    # we need to inform testing script which frameworks to use
+    # this is done by setting a flag EINOPS_TEST_BACKENDS
+    from tests import unparse_backends
+
+    flag_name, flag_value = unparse_backends(backend_names=frameworks)
+    return_code = run(
+        "python -m pytest tests",
+        **{flag_name: flag_value},
+    )
     assert return_code == 0
 
-# install dependencies
-dependencies = [
-    'numpy',
-    'torch',
-    'tensorflow',
-    'chainer',
-    'jax',
-    'jaxlib',
-    'flax',
-    'nbformat',
-    'nbconvert',
-    'jupyter',
-    'parameterized',
-    'pillow',
-    'pytest',
-]
 
-assert 0 == run('pip install {} --progress-bar off'.format(' '.join(dependencies)))
-
-# install paddle. It's need to install the latest version.
-assert 0 == run('pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html --user')
-# latest paddle requires >=3.20.2, so use 3.20.3
-assert 0 == run('pip install protobuf==3.20.3')
-
-# oneflow provides wheels for linux, but not mac, so it is tested only on linux
-skip_oneflow = 'linux' not in sys.platform
-skip_oneflow = True
-
-if not skip_oneflow:
-    # oneflow installation: https://github.com/Oneflow-Inc/oneflow#install-with-pip-package
-    assert 0 == run('pip install -f https://release.oneflow.info oneflow==0.7.0+cpu --user')
-
-# install einops
-assert 0 == run('pip install -e .')
-
-
-return_code = run(
-    'python -m pytest tests',
-    EINOPS_SKIP_CUPY='1' if skip_cupy else '0',
-    EINOPS_SKIP_ONEFLOW='1' if skip_oneflow else '0',
-)
-assert return_code == 0
-
-if __name__ == '__main__':
-    # minor convenience for lazy me to start debugging in pycharm
-    pass
+if __name__ == "__main__":
+    main()

--- a/test.py
+++ b/test.py
@@ -35,14 +35,14 @@ def main():
     _executable, *frameworks = sys.argv
     framework_name2installation = {
         "numpy": ["numpy"],
-        "pytorch": ["torch"],
+        "torch": ["torch"],
         "jax": ["jax", "jaxlib"],
         "flax": ["flax", "jax", "jaxlib"],
         "tensorflow": ["tensorflow"],
         "chainer": ["chainer"],
         "cupy": ["cupy"],
         "paddle": ["paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html"],
-        "oneflow": ["oneflow==0.7.0+cpu -f https://release.oneflow.info"],
+        "oneflow": ["oneflow==0.9.0+cpu -f https://release.oneflow.info"],
     }
 
     usage = f"""
@@ -57,7 +57,7 @@ def main():
     else:
         synonyms = {
             "tf": "tensorflow",
-            "torch": "pytorch",
+            "pytorch": "torch",
             "paddlepaddle": "paddle",
         }
         frameworks = [synonyms.get(f, f) for f in frameworks]

--- a/test.py
+++ b/test.py
@@ -50,10 +50,14 @@ dependencies = [
     'parameterized',
     'pillow',
     'pytest',
-    'paddlepaddle'
 ]
 
 assert 0 == run('pip install {} --progress-bar off'.format(' '.join(dependencies)))
+
+# install paddle. It's need to install the latest version.
+assert 0 == run('pip install paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html --user')
+# latest paddle requires >=3.20.2, so use 3.20.3
+assert 0 == run('pip install protobuf==3.20.3')
 
 # oneflow provides wheels for linux, but not mac, so it is tested only on linux
 skip_oneflow = 'linux' not in sys.platform

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -39,6 +39,11 @@ def parse_backends_to_test() -> List[str]:
 
     return parsed_backends
 
+def is_backend_tested(backend: str) -> bool:
+    if backend not in find_names_of_all_frameworks():
+        raise RuntimeError(f'Unknown framework {backend}')
+    return backend in parse_backends_to_test()
+
 
 def unparse_backends(backend_names: List[str]) -> Tuple[str, str]:
     _known_backends = find_names_of_all_frameworks()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from functools import lru_cache
+from typing import List, Tuple
 
 from einops import _backends
 import warnings
@@ -13,7 +14,7 @@ logging.getLogger("tensorflow").disabled = True
 logging.getLogger("matplotlib").disabled = True
 
 
-def find_names_of_all_frameworks() -> list[str]:
+def find_names_of_all_frameworks() -> List[str]:
     backend_subclasses = []
     backends = _backends.AbstractBackend.__subclasses__()
     while backends:
@@ -27,11 +28,9 @@ FLAG_NAME = "EINOPS_TEST_BACKENDS"
 
 
 @lru_cache(maxsize=1)
-def parse_backends_to_test() -> list[str]:
+def parse_backends_to_test() -> List[str]:
     if FLAG_NAME not in os.environ:
-        raise RuntimeError(
-            f"Testing frameworks were not specified, flag {FLAG_NAME} not set"
-        )
+        raise RuntimeError(f"Testing frameworks were not specified, flag {FLAG_NAME} not set")
     parsed_backends = os.environ[FLAG_NAME].split(",")
     _known_backends = find_names_of_all_frameworks()
     for backend_name in parsed_backends:
@@ -41,7 +40,7 @@ def parse_backends_to_test() -> list[str]:
     return parsed_backends
 
 
-def unparse_backends(backend_names: list[str]) -> tuple[str, str]:
+def unparse_backends(backend_names: List[str]) -> Tuple[str, str]:
     _known_backends = find_names_of_all_frameworks()
     for backend_name in backend_names:
         if backend_name not in _known_backends:
@@ -94,7 +93,5 @@ def collect_test_backends(symbolic=False, layers=False):
         except ImportError:
             # problem with backend installation fails a specific test function,
             # but will be skipped in all other test cases
-            warnings.warn(
-                "backend could not be initialized for tests: {}".format(backend_type)
-            )
+            warnings.warn("backend could not be initialized for tests: {}".format(backend_type))
     return result

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -48,7 +48,7 @@ def unparse_backends(backend_names: List[str]) -> Tuple[str, str]:
     return FLAG_NAME, ",".join(backend_names)
 
 
-def collect_test_backends(symbolic=False, layers=False):
+def collect_test_backends(symbolic=False, layers=False) -> List[_backends.AbstractBackend]:
     """
     :param symbolic: symbolic or imperative frameworks?
     :param layers: layers or operations?

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -37,6 +37,7 @@ def collect_test_backends(symbolic=False, layers=False):
                 _backends.ChainerBackend,
                 _backends.TensorflowBackend,
                 _backends.OneFlowBackend,
+                _backends.PaddleBackend,
             ]
             if not skip_cupy:
                 backend_types += [_backends.CupyBackend]
@@ -46,6 +47,7 @@ def collect_test_backends(symbolic=False, layers=False):
                 _backends.GluonBackend,
                 _backends.ChainerBackend,
                 _backends.OneFlowBackend,
+                _backends.PaddleBackend,
             ]
     else:
         if not layers:

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -214,7 +214,7 @@ def test_functional():
                     out_array = einsum(*in_arrays_framework, einops_pattern)
 
                 # Check shape:
-                if out_array.shape != out_shape:
+                if tuple(out_array.shape) != out_shape:
                     raise ValueError(
                         f"Expected output shape {out_shape} but got {out_array.shape}"
                     )

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -167,7 +167,7 @@ test_functional_cases = [
 
 def test_layer():
     for backend in collect_test_backends(layers=True, symbolic=False):
-        if backend.framework_name in ['tensorflow', 'torch', 'chainer', 'oneflow']:
+        if backend.framework_name in ['tensorflow', 'torch', 'chainer', 'oneflow', 'paddle']:
             layer_type = backend.layers().EinMix
             for args, in_shape, out_shape in test_layer_cases:
                 layer = args(layer_type)

--- a/tests/test_einsum.py
+++ b/tests/test_einsum.py
@@ -180,7 +180,7 @@ def test_layer():
 
 
 valid_backends_functional = ['tensorflow', 'torch', 'jax', 'numpy',
-                             'chainer', 'oneflow', 'cupy', 'tensorflow.keras']
+                             'chainer', 'oneflow', 'cupy', 'tensorflow.keras', 'paddle']
 
 def test_functional():
     # Functional tests:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -9,76 +9,76 @@ def test_rearrange_examples():
     def test1(x):
         # transpose
         y = rearrange(x, 'b c h w -> b h w c')
-        assert y.shape == (10, 30, 40, 20)
+        assert tuple(y.shape) == (10, 30, 40, 20)
         return y
 
     def test2(x):
         # view / reshape
         y = rearrange(x, 'b c h w -> b (c h w)')
-        assert y.shape == (10, 20 * 30 * 40)
+        assert tuple(y.shape) == (10, 20 * 30 * 40)
         return y
 
     def test3(x):
         # depth-to-space
         y = rearrange(x, 'b (c h1 w1) h w -> b c (h h1) (w w1)', h1=2, w1=2)
-        assert y.shape == (10, 5, 30 * 2, 40 * 2)
+        assert tuple(y.shape) == (10, 5, 30 * 2, 40 * 2)
         return y
 
     def test4(x):
         # space-to-depth
         y = rearrange(x, 'b c (h h1) (w w1) -> b (h1 w1 c) h w', h1=2, w1=2)
-        assert y.shape == (10, 20 * 4, 30 // 2, 40 // 2)
+        assert tuple(y.shape) == (10, 20 * 4, 30 // 2, 40 // 2)
         return y
 
     def test5(x):
         # simple transposition
         y = rearrange(x, 'b1 sound b2 letter -> b1 b2 sound letter')
-        assert y.shape == (10, 30, 20, 40)
+        assert tuple(y.shape) == (10, 30, 20, 40)
         return y
 
     def test6(x):
         # parsing parameters
         t = rearrange(x, 'b c h w -> (b h w) c')
         t = t[:, ::2]  # replacement for dot-product, just changes size of second axis
-        assert t.shape == (10 * 30 * 40, 10)
+        assert tuple(t.shape) == (10 * 30 * 40, 10)
 
         y = rearrange(t, '(b h w) c2 -> b c2 h w', **parse_shape(x, 'b _ h w'))
-        assert y.shape == (10, 10, 30, 40)
+        assert tuple(y.shape) == (10, 10, 30, 40)
         return y
 
     def test7(x):
         # split of embedding into groups
         y1, y2 = rearrange(x, 'b (c g) h w -> g b c h w', g=2)
-        assert y1.shape == (10, 10, 30, 40)
-        assert y2.shape == (10, 10, 30, 40)
+        assert tuple(y1.shape) == (10, 10, 30, 40)
+        assert tuple(y2.shape) == (10, 10, 30, 40)
         return y1 + y2  # only one tensor is expected in output
 
     def test8(x):
         # max-pooling
         y = reduce(x, 'b c (h h1) (w w1) -> b c h w', reduction='max', h1=2, w1=2)
-        assert y.shape == (10, 20, 30 // 2, 40 // 2)
+        assert tuple(y.shape) == (10, 20, 30 // 2, 40 // 2)
         return y
 
     def test9(x):
         # squeeze - unsqueeze
         y = reduce(x, 'b c h w -> b c () ()', reduction='max')
-        assert y.shape == (10, 20, 1, 1)
+        assert tuple(y.shape) == (10, 20, 1, 1)
         y = rearrange(y, 'b c () () -> c b')
-        assert y.shape == (20, 10)
+        assert tuple(y.shape) == (20, 10)
         return y
 
     def test10(x):
         # stack
         tensors = list(x + 0)  # 0 is needed https://github.com/tensorflow/tensorflow/issues/23185
         tensors = rearrange(tensors, 'b c h w -> b h w c')
-        assert tensors.shape == (10, 30, 40, 20)
+        assert tuple(tensors.shape) == (10, 30, 40, 20)
         return tensors
 
     def test11(x):
         # concatenate
         tensors = list(x + 0)  # 0 is needed https://github.com/tensorflow/tensorflow/issues/23185
         tensors = rearrange(tensors, 'b c h w -> h (b w) c')
-        assert tensors.shape == (30, 10 * 40, 20)
+        assert tuple(tensors.shape) == (30, 10 * 40, 20)
         return tensors
 
     def shufflenet(x, convolve, c1, c2):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,8 @@
 import numpy
+import pytest
 
 from einops import rearrange, parse_shape, reduce
-from tests import parse_backends_to_test
+from tests import is_backend_tested
 from tests.test_ops import imp_op_backends
 
 
@@ -179,11 +180,10 @@ def tensor_train_example_numpy():
 
 
 def test_pytorch_yolo_fragment():
-    if 'torch' not in parse_backends_to_test():
-        return
-    
-    import torch
+    if not is_backend_tested('torch'):
+        pytest.skip()
 
+    import torch
     def old_way(input, num_classes, num_anchors, anchors, stride_h, stride_w):
         # https://github.com/BobLiu20/YOLOv3_PyTorch/blob/c6b483743598b5f64d520d81e7e5f47ba936d4c9/nets/yolo_loss.py#L28-L44
         bs = input.size(0)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,7 +1,7 @@
 import numpy
 
 from einops import rearrange, parse_shape, reduce
-from tests import collect_test_backends
+from tests import parse_backends_to_test
 from tests.test_ops import imp_op_backends
 
 
@@ -179,8 +179,9 @@ def tensor_train_example_numpy():
 
 
 def test_pytorch_yolo_fragment():
-    if not any(b.framework_name == 'torch' for b in collect_test_backends(symbolic=False, layers=False)):
+    if 'torch' not in parse_backends_to_test():
         return
+    
     import torch
 
     def old_way(input, num_classes, num_anchors, anchors, stride_h, stride_w):

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -3,41 +3,53 @@ import tempfile
 from collections import namedtuple
 
 import numpy
-import torch.jit
+import pytest
 
 from einops import rearrange, reduce
 from einops.einops import _reductions
 from . import collect_test_backends
 
-__author__ = 'Alex Rogozhnikov'
+__author__ = "Alex Rogozhnikov"
 
-testcase = namedtuple('testcase', ['pattern', 'axes_lengths', 'input_shape', 'wrong_shapes'])
+testcase = namedtuple("testcase", ["pattern", "axes_lengths", "input_shape", "wrong_shapes"])
 
 rearrangement_patterns = [
-    testcase('b c h w -> b (c h w)', dict(c=20), (10, 20, 30, 40),
-             [(), (10,), (10, 10, 10), (10, 21, 30, 40), [1, 20, 1, 1, 1]]),
-    testcase('b c (h1 h2) (w1 w2) -> b (c h2 w2) h1 w1', dict(h2=2, w2=2), (10, 20, 30, 40),
-             [(), (1, 1, 1, 1), (1, 10, 3), ()]),
-    testcase('b ... c -> c b ...', dict(b=10), (10, 20, 30),
-             [(), (10,), (5, 10)]),
+    testcase(
+        "b c h w -> b (c h w)",
+        dict(c=20),
+        (10, 20, 30, 40),
+        [(), (10,), (10, 10, 10), (10, 21, 30, 40), [1, 20, 1, 1, 1]],
+    ),
+    testcase(
+        "b c (h1 h2) (w1 w2) -> b (c h2 w2) h1 w1",
+        dict(h2=2, w2=2),
+        (10, 20, 30, 40),
+        [(), (1, 1, 1, 1), (1, 10, 3), ()],
+    ),
+    testcase(
+        "b ... c -> c b ...",
+        dict(b=10),
+        (10, 20, 30),
+        [(), (10,), (5, 10)],
+    ),
 ]
 
 
 def test_rearrange_imperative():
     for backend in collect_test_backends(symbolic=False, layers=True):
-        print('Test layer for ', backend.framework_name)
+        print("Test layer for ", backend.framework_name)
 
         for pattern, axes_lengths, input_shape, wrong_shapes in rearrangement_patterns:
-            x = numpy.arange(numpy.prod(input_shape), dtype='float32').reshape(input_shape)
+            x = numpy.arange(numpy.prod(input_shape), dtype="float32").reshape(input_shape)
             result_numpy = rearrange(x, pattern, **axes_lengths)
             layer = backend.layers().Rearrange(pattern, **axes_lengths)
             for shape in wrong_shapes:
                 try:
-                    layer(backend.from_numpy(numpy.zeros(shape, dtype='float32')))
+                    layer(backend.from_numpy(numpy.zeros(shape, dtype="float32")))
                 except:
                     pass
                 else:
-                    raise AssertionError('Failure expected')
+                    raise AssertionError("Failure expected")
 
             # simple pickling / unpickling
             layer2 = pickle.loads(pickle.dumps(layer))
@@ -46,9 +58,9 @@ def test_rearrange_imperative():
             assert numpy.allclose(result_numpy, result1)
             assert numpy.allclose(result1, result2)
 
-            just_sum = backend.layers().Reduce('...->', reduction='sum')
+            just_sum = backend.layers().Reduce("...->", reduction="sum")
 
-            if 'mxnet' in backend.framework_name:
+            if "mxnet" in backend.framework_name:
                 with backend.mx.autograd.record():
                     variable = backend.from_numpy(x)
                     result = just_sum(layer(variable))
@@ -62,14 +74,14 @@ def test_rearrange_imperative():
 
 def test_rearrange_symbolic():
     for backend in collect_test_backends(symbolic=True, layers=True):
-        print('Test layer for ', backend.framework_name)
+        print("Test layer for ", backend.framework_name)
 
         for pattern, axes_lengths, input_shape, wrong_shapes in rearrangement_patterns:
-            x = numpy.arange(numpy.prod(input_shape), dtype='float32').reshape(input_shape)
+            x = numpy.arange(numpy.prod(input_shape), dtype="float32").reshape(input_shape)
             result_numpy = rearrange(x, pattern, **axes_lengths)
             layer = backend.layers().Rearrange(pattern, **axes_lengths)
             shapes = [input_shape]
-            if 'mxnet' not in backend.framework_name:
+            if "mxnet" not in backend.framework_name:
                 shapes.append([None] * len(input_shape))
 
             for shape in shapes:
@@ -86,7 +98,7 @@ def test_rearrange_symbolic():
                 assert numpy.allclose(result1, result2)
 
                 # now testing back-propagation
-                just_sum = backend.layers().Reduce('...->', reduction='sum')
+                just_sum = backend.layers().Reduce("...->", reduction="sum")
 
                 result_sum1 = backend.eval_symbol(just_sum(result_symbol1), eval_inputs)
                 result_sum2 = numpy.sum(x)
@@ -95,32 +107,29 @@ def test_rearrange_symbolic():
 
 
 reduction_patterns = rearrangement_patterns + [
-    testcase('b c h w -> b ()', dict(b=10), (10, 20, 30, 40),
-             [(10,), (10, 20, 30)]),
-    testcase('b c (h1 h2) (w1 w2) -> b c h1 w1', dict(h1=15, h2=2, w2=2), (10, 20, 30, 40),
-             [(10, 20, 31, 40)]),
-    testcase('b ... c -> b', dict(b=10), (10, 20, 30, 40),
-             [(10,), (11, 10)]),
+    testcase("b c h w -> b ()", dict(b=10), (10, 20, 30, 40), [(10,), (10, 20, 30)]),
+    testcase("b c (h1 h2) (w1 w2) -> b c h1 w1", dict(h1=15, h2=2, w2=2), (10, 20, 30, 40), [(10, 20, 31, 40)]),
+    testcase("b ... c -> b", dict(b=10), (10, 20, 30, 40), [(10,), (11, 10)]),
 ]
 
 
 def test_reduce_imperative():
     for backend in collect_test_backends(symbolic=False, layers=True):
-        print('Test layer for ', backend.framework_name)
+        print("Test layer for ", backend.framework_name)
         for reduction in _reductions:
             for pattern, axes_lengths, input_shape, wrong_shapes in reduction_patterns:
                 print(backend, reduction, pattern, axes_lengths, input_shape, wrong_shapes)
-                x = numpy.arange(1, 1 + numpy.prod(input_shape), dtype='float32').reshape(input_shape)
+                x = numpy.arange(1, 1 + numpy.prod(input_shape), dtype="float32").reshape(input_shape)
                 x /= x.mean()
                 result_numpy = reduce(x, pattern, reduction, **axes_lengths)
                 layer = backend.layers().Reduce(pattern, reduction, **axes_lengths)
                 for shape in wrong_shapes:
                     try:
-                        layer(backend.from_numpy(numpy.zeros(shape, dtype='float32')))
+                        layer(backend.from_numpy(numpy.zeros(shape, dtype="float32")))
                     except:
                         pass
                     else:
-                        raise AssertionError('Failure expected')
+                        raise AssertionError("Failure expected")
 
                 # simple pickling / unpickling
                 layer2 = pickle.loads(pickle.dumps(layer))
@@ -129,9 +138,9 @@ def test_reduce_imperative():
                 assert numpy.allclose(result_numpy, result1)
                 assert numpy.allclose(result1, result2)
 
-                just_sum = backend.layers().Reduce('...->', reduction='sum')
+                just_sum = backend.layers().Reduce("...->", reduction="sum")
 
-                if 'mxnet' in backend.framework_name:
+                if "mxnet" in backend.framework_name:
                     with backend.mx.autograd.record():
                         variable = backend.from_numpy(x)
                         result = just_sum(layer(variable))
@@ -141,26 +150,26 @@ def test_reduce_imperative():
 
                 result.backward()
                 grad = backend.to_numpy(variable.grad)
-                if reduction == 'sum':
+                if reduction == "sum":
                     assert numpy.allclose(grad, 1)
-                if reduction == 'mean':
+                if reduction == "mean":
                     assert numpy.allclose(grad, grad.min())
-                if reduction in ['max', 'min']:
+                if reduction in ["max", "min"]:
                     assert numpy.all(numpy.in1d(grad, [0, 1]))
                     assert numpy.sum(grad) > 0.5
 
 
 def test_reduce_symbolic():
     for backend in collect_test_backends(symbolic=True, layers=True):
-        print('Test layer for ', backend.framework_name)
+        print("Test layer for ", backend.framework_name)
         for reduction in _reductions:
             for pattern, axes_lengths, input_shape, wrong_shapes in reduction_patterns:
-                x = numpy.arange(1, 1 + numpy.prod(input_shape), dtype='float32').reshape(input_shape)
+                x = numpy.arange(1, 1 + numpy.prod(input_shape), dtype="float32").reshape(input_shape)
                 x /= x.mean()
                 result_numpy = reduce(x, pattern, reduction, **axes_lengths)
                 layer = backend.layers().Reduce(pattern, reduction, **axes_lengths)
                 shapes = [input_shape]
-                if 'mxnet' not in backend.framework_name:
+                if "mxnet" not in backend.framework_name:
                     shapes.append([None] * len(input_shape))
 
                 for shape in shapes:
@@ -177,52 +186,69 @@ def test_reduce_symbolic():
                     assert numpy.allclose(result1, result2)
 
 
+is_torch_tested = any(
+    backend.framework_name == "torch" for backend in collect_test_backends(symbolic=False, layers=True)
+)
+
+
 def create_torch_model(use_reduce=False, add_scripted_layer=False):
+    if not is_torch_tested:
+        pytest.skip("Torch not tested")
+
     from torch.nn import Sequential, Conv2d, MaxPool2d, Linear, ReLU
     from einops.layers.torch import Rearrange, Reduce, EinMix
+    import torch.jit
+
     return Sequential(
         Conv2d(3, 6, kernel_size=(5, 5)),
-        Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2) if use_reduce else MaxPool2d(kernel_size=2),
+        Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2) if use_reduce else MaxPool2d(kernel_size=2),
         Conv2d(6, 16, kernel_size=(5, 5)),
-        Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
-        torch.jit.script(Rearrange('b c h w -> b (c h w)'))
-        if add_scripted_layer else Rearrange('b c h w -> b (c h w)'),
+        Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
+        torch.jit.script(Rearrange("b c h w -> b (c h w)"))
+        if add_scripted_layer
+        else Rearrange("b c h w -> b (c h w)"),
         Linear(16 * 5 * 5, 120),
         ReLU(),
         Linear(120, 84),
         ReLU(),
-        EinMix('b c1 -> (b c2)', weight_shape='c1 c2', bias_shape='c2', c1=84, c2=84),
-        EinMix('(b c2) -> b c3', weight_shape='c2 c3', bias_shape='c3', c2=84, c3=84),
+        EinMix("b c1 -> (b c2)", weight_shape="c1 c2", bias_shape="c2", c1=84, c2=84),
+        EinMix("(b c2) -> b c3", weight_shape="c2 c3", bias_shape="c3", c2=84, c3=84),
         Linear(84, 10),
     )
 
 
 def test_torch_layer():
-    has_torch = any(backend.framework_name == 'torch' for backend in collect_test_backends(symbolic=False, layers=True))
-    if has_torch:
-        # checked that torch present
-        import torch
+    if not is_torch_tested:
+        pytest.skip("Torch not tested")
 
-        model1 = create_torch_model(use_reduce=True)
-        model2 = create_torch_model(use_reduce=False)
-        input = torch.randn([10, 3, 32, 32])
-        # random models have different predictions
-        assert not torch.allclose(model1(input), model2(input))
-        model2.load_state_dict(pickle.loads(pickle.dumps(model1.state_dict())))
-        assert torch.allclose(model1(input), model2(input))
+    # checked that torch present
+    import torch
+    import torch.jit
 
-        # tracing (freezing)
-        model3 = torch.jit.trace(model2, example_inputs=input)
-        torch.testing.assert_close(model1(input), model3(input), atol=1e-3, rtol=1e-3)
-        torch.testing.assert_close(model1(input + 1), model3(input + 1), atol=1e-3, rtol=1e-3)
+    model1 = create_torch_model(use_reduce=True)
+    model2 = create_torch_model(use_reduce=False)
+    input = torch.randn([10, 3, 32, 32])
+    # random models have different predictions
+    assert not torch.allclose(model1(input), model2(input))
+    model2.load_state_dict(pickle.loads(pickle.dumps(model1.state_dict())))
+    assert torch.allclose(model1(input), model2(input))
 
-        model4 = torch.jit.trace(model2, example_inputs=input)
-        torch.testing.assert_close(model1(input), model4(input), atol=1e-3, rtol=1e-3)
-        torch.testing.assert_close(model1(input + 1), model4(input + 1), atol=1e-3, rtol=1e-3)
+    # tracing (freezing)
+    model3 = torch.jit.trace(model2, example_inputs=input)
+    torch.testing.assert_close(model1(input), model3(input), atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(model1(input + 1), model3(input + 1), atol=1e-3, rtol=1e-3)
+
+    model4 = torch.jit.trace(model2, example_inputs=input)
+    torch.testing.assert_close(model1(input), model4(input), atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(model1(input + 1), model4(input + 1), atol=1e-3, rtol=1e-3)
 
 
 def test_torch_layers_scripting():
+    if not is_torch_tested:
+        pytest.skip("Torch not tested")
+
     import torch
+
     for script_layer in [False, True]:
         model1 = create_torch_model(use_reduce=True, add_scripted_layer=script_layer)
         model2 = torch.jit.script(model1)
@@ -232,7 +258,9 @@ def test_torch_layers_scripting():
 
 
 def test_keras_layer():
-    if any(backend.framework_name == 'tensorflow.keras' for backend in collect_test_backends(symbolic=True, layers=True)):
+    if any(
+        backend.framework_name == "tensorflow.keras" for backend in collect_test_backends(symbolic=True, layers=True)
+    ):
         # checked that keras present
 
         import tensorflow as tf
@@ -241,31 +269,33 @@ def test_keras_layer():
         from einops.layers.keras import Rearrange, Reduce, EinMix, keras_custom_objects
 
         def create_keras_model():
-            return Sequential([
-                Conv2d(6, kernel_size=5, input_shape=[32, 32, 3]),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
-                Conv2d(16, kernel_size=5),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
-                Rearrange('b c h w -> b (c h w)'),
-                Linear(120),
-                ReLU(),
-                Linear(84),
-                ReLU(),
-                EinMix('b c1 -> (b c2)', weight_shape='c1 c2', bias_shape='c2', c1=84, c2=84),
-                EinMix('(b c2) -> b c3', weight_shape='c2 c3', bias_shape='c3', c2=84, c3=84),
-                Linear(10),
-            ])
+            return Sequential(
+                [
+                    Conv2d(6, kernel_size=5, input_shape=[32, 32, 3]),
+                    Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
+                    Conv2d(16, kernel_size=5),
+                    Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
+                    Rearrange("b c h w -> b (c h w)"),
+                    Linear(120),
+                    ReLU(),
+                    Linear(84),
+                    ReLU(),
+                    EinMix("b c1 -> (b c2)", weight_shape="c1 c2", bias_shape="c2", c1=84, c2=84),
+                    EinMix("(b c2) -> b c3", weight_shape="c2 c3", bias_shape="c3", c2=84, c3=84),
+                    Linear(10),
+                ]
+            )
 
         model1 = create_keras_model()
         model2 = create_keras_model()
-        input = numpy.random.normal(size=[10, 32, 32, 3]).astype('float32')
+        input = numpy.random.normal(size=[10, 32, 32, 3]).astype("float32")
         assert not numpy.allclose(model1.predict_on_batch(input), model2.predict_on_batch(input))
 
         # get some temp filename
-        with tempfile.NamedTemporaryFile(mode='r+b') as f:
+        with tempfile.NamedTemporaryFile(mode="r+b") as f:
             tmp_filename = f.name
         # save arch + weights
-        print('temp_path_keras1', tmp_filename)
+        print("temp_path_keras1", tmp_filename)
         tf.keras.models.save_model(model1, tmp_filename)
         model3 = tf.keras.models.load_model(tmp_filename, custom_objects=keras_custom_objects)
         assert numpy.allclose(model1.predict_on_batch(input), model3.predict_on_batch(input))
@@ -281,7 +311,7 @@ def test_keras_layer():
 
 def test_gluon_layer():
     gluon_is_present = any(
-        'mxnet' in backend.framework_name for backend in collect_test_backends(symbolic=False, layers=True)
+        "mxnet" in backend.framework_name for backend in collect_test_backends(symbolic=False, layers=True)
     )
     if gluon_is_present:
         # checked that gluon present
@@ -294,10 +324,10 @@ def test_gluon_layer():
             model = HybridSequential()
             layers = [
                 Conv2D(6, kernel_size=5),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
+                Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
                 Conv2D(16, kernel_size=5),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
-                Rearrange('b c h w -> b (c h w)'),
+                Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
+                Rearrange("b c h w -> b (c h w)"),
                 Dense(120),
                 LeakyReLU(alpha=0.0),
                 Dense(84),
@@ -314,21 +344,21 @@ def test_gluon_layer():
         x = mxnet.ndarray.random_normal(shape=[10, 3, 32, 32])
         assert not numpy.allclose(asnumpy(model1(x)), asnumpy(model2(x)))
 
-        with tempfile.NamedTemporaryFile(mode='r+b') as fp:
+        with tempfile.NamedTemporaryFile(mode="r+b") as fp:
             model1.save_parameters(fp.name)
             model2.load_parameters(fp.name)
 
         assert numpy.allclose(asnumpy(model1(x)), asnumpy(model2(x)))
 
         # testing with symbolic (NB with fixed dimensions!)
-        input = mxnet.sym.Variable('data', shape=x.shape)
+        input = mxnet.sym.Variable("data", shape=x.shape)
         json = model1(input).tojson()
         model3 = mxnet.gluon.SymbolBlock(outputs=mxnet.sym.load_json(json), inputs=input)
         model4 = mxnet.gluon.SymbolBlock(outputs=mxnet.sym.load_json(json), inputs=input)
         model3.initialize(ctx=mxnet.cpu())
         model3(x)
 
-        with tempfile.NamedTemporaryFile(mode='r+b') as fp:
+        with tempfile.NamedTemporaryFile(mode="r+b") as fp:
             model3.save_parameters(fp.name)
             model4.load_parameters(fp.name)
         assert numpy.allclose(asnumpy(model3(x)), asnumpy(model4(x)))
@@ -343,7 +373,7 @@ def test_gluon_layer():
 
 def test_chainer_layer():
     chainer_is_present = any(
-        'chainer' in backend.framework_name for backend in collect_test_backends(symbolic=False, layers=True)
+        "chainer" in backend.framework_name for backend in collect_test_backends(symbolic=False, layers=True)
     )
     if chainer_is_present:
         # checked that gluon present
@@ -357,26 +387,26 @@ def test_chainer_layer():
         def create_model():
             return chainer.Sequential(
                 L.Convolution2D(3, 6, ksize=(5, 5)),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
+                Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
                 L.Convolution2D(6, 16, ksize=(5, 5)),
-                Reduce('b c (h h2) (w w2) -> b c h w', 'max', h2=2, w2=2),
-                Rearrange('b c h w -> b (c h w)'),
+                Reduce("b c (h h2) (w w2) -> b c h w", "max", h2=2, w2=2),
+                Rearrange("b c h w -> b (c h w)"),
                 L.Linear(16 * 5 * 5, 120),
                 L.Linear(120, 84),
                 F.relu,
-                EinMix('b c1 -> (b c2)', weight_shape='c1 c2', bias_shape='c2', c1=84, c2=84),
-                EinMix('(b c2) -> b c3', weight_shape='c2 c3', bias_shape='c3', c2=84, c3=84),
+                EinMix("b c1 -> (b c2)", weight_shape="c1 c2", bias_shape="c2", c1=84, c2=84),
+                EinMix("(b c2) -> b c3", weight_shape="c2 c3", bias_shape="c3", c2=84, c3=84),
                 L.Linear(84, 10),
             )
 
         model1 = create_model()
         model2 = create_model()
-        x = np.random.normal(size=[10, 3, 32, 32]).astype('float32')
+        x = np.random.normal(size=[10, 3, 32, 32]).astype("float32")
         x = chainer.Variable(x)
         assert not numpy.allclose(asnumpy(model1(x)), asnumpy(model2(x)))
 
         with tempfile.TemporaryDirectory() as dir:
-            filename = f'{dir}/file.npz'
+            filename = f"{dir}/file.npz"
             chainer.serializers.save_npz(filename, model1)
             chainer.serializers.load_npz(filename, model2)
 
@@ -388,39 +418,42 @@ def test_flax_layers():
     One-off simple tests for Flax layers.
     Unfortunately, Flax layers have a different interface from other layers.
     """
-    import jax
-    import jax.numpy as jnp
-
-    import flax
-    from flax import linen as nn
-    from einops.layers.flax import EinMix, Reduce, Rearrange
-
-    class NN(nn.Module):
-        @nn.compact
-        def __call__(self, x):
-            x = EinMix('b (h h2) (w w2) c -> b h w c_out', 'h2 w2 c c_out', 'c_out', sizes=dict(h2=2, w2=3, c=4, c_out=5) )(x)
-            x = Rearrange('b h w c -> b (w h c)', sizes=dict(c=5))(x)
-            x = Reduce('b hwc -> b', 'mean', dict(hwc=2 * 3 * 5))(x)
-            return x
-
-    model = NN()
-    fixed_input = jnp.ones([10, 2 * 2, 3 * 3, 4])
-    params = model.init(jax.random.PRNGKey(0), fixed_input)
-    eval_at_point = lambda params: jnp.linalg.norm(model.apply(params, fixed_input))
-
-    vandg = jax.value_and_grad(eval_at_point)
-    value0 = eval_at_point(params)
-    value1, grad1 = vandg(params)
-    assert jnp.allclose(value0, value1)
-
-    params2 = jax.tree_map(
-        lambda x1, x2: x1 - x2 * 0.001,
-        params, grad1
+    flax_is_present = any(
+        "flax" in backend.framework_name for backend in collect_test_backends(symbolic=False, layers=True)
     )
+    if flax_is_present:
+        import jax
+        import jax.numpy as jnp
 
-    value2 = eval_at_point(params2)
-    assert value0 >= value2, (value0, value2)
+        import flax
+        from flax import linen as nn
+        from einops.layers.flax import EinMix, Reduce, Rearrange
 
-    # check serialization
-    fbytes = flax.serialization.to_bytes(params)
-    _loaded = flax.serialization.from_bytes(params, fbytes)
+        class NN(nn.Module):
+            @nn.compact
+            def __call__(self, x):
+                x = EinMix(
+                    "b (h h2) (w w2) c -> b h w c_out", "h2 w2 c c_out", "c_out", sizes=dict(h2=2, w2=3, c=4, c_out=5)
+                )(x)
+                x = Rearrange("b h w c -> b (w h c)", sizes=dict(c=5))(x)
+                x = Reduce("b hwc -> b", "mean", dict(hwc=2 * 3 * 5))(x)
+                return x
+
+        model = NN()
+        fixed_input = jnp.ones([10, 2 * 2, 3 * 3, 4])
+        params = model.init(jax.random.PRNGKey(0), fixed_input)
+        eval_at_point = lambda params: jnp.linalg.norm(model.apply(params, fixed_input))
+
+        vandg = jax.value_and_grad(eval_at_point)
+        value0 = eval_at_point(params)
+        value1, grad1 = vandg(params)
+        assert jnp.allclose(value0, value1)
+
+        params2 = jax.tree_map(lambda x1, x2: x1 - x2 * 0.001, params, grad1)
+
+        value2 = eval_at_point(params2)
+        assert value0 >= value2, (value0, value2)
+
+        # check serialization
+        fbytes = flax.serialization.to_bytes(params)
+        _loaded = flax.serialization.from_bytes(params, fbytes)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from io import StringIO
 
-from tests import collect_test_backends
+from tests import parse_backends_to_test
 
 __author__ = "Alex Rogozhnikov"
 
@@ -39,13 +39,11 @@ def test_notebook_1():
 
 def test_notebook_2_with_all_backends():
     [notebook] = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
-    backends = []
-    if "chainer" in collect_test_backends(symbolic=False, layers=True):
-        backends += ["chainer"]
-    if "pytorch" in collect_test_backends(symbolic=False, layers=True):
-        backends += ["pytorch"]
-    if "tensorflow" in collect_test_backends(symbolic=False, layers=False):
-        backends += ["tensorflow"]
+    backends = ['chainer', 'torch', 'tensorflow']
+    backends = [b for b in backends if b in parse_backends_to_test()]
+    if len(backends) == 0:
+        pytest.skip()
+
     for backend in backends:
         print("Testing {} with backend {}".format(notebook, backend))
         replacements = {"flavour = 'pytorch'": "flavour = '{}'".format(backend)}
@@ -56,13 +54,13 @@ def test_notebook_2_with_all_backends():
 
 def test_notebook_3():
     [notebook] = Path(__file__).parent.with_name("docs").glob("3-*.ipynb")
-    if "pytorch" not in collect_test_backends(symbolic=False, layers=True):
+    if "torch" not in parse_backends_to_test():
         pytest.skip()
     render_notebook(notebook, replacements={})
 
 
 def test_notebook_4():
     [notebook] = Path(__file__).parent.with_name("docs").glob("4-*.ipynb")
-    if "pytorch" not in collect_test_backends(symbolic=False, layers=True):
+    if "torch" not in parse_backends_to_test():
         pytest.skip()
     render_notebook(notebook, replacements={})

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -8,6 +8,7 @@ __author__ = "Alex Rogozhnikov"
 
 from pathlib import Path
 import nbformat
+import pytest
 from nbconvert.preprocessors import ExecutePreprocessor
 
 
@@ -31,14 +32,13 @@ def render_notebook(filename: Path, replacements: Dict[str, str]) -> str:
     return result_as_stream.getvalue()
 
 
-def test_all_notebooks():
-    notebooks = Path(__file__).parent.with_name("docs").glob("*.ipynb")
-    for notebook in notebooks:
-        render_notebook(notebook, replacements={})
+def test_notebook_1():
+    [notebook] = Path(__file__).parent.with_name("docs").glob("1-*.ipynb")
+    render_notebook(notebook, replacements={})
 
 
-def test_dl_notebook_with_all_backends():
-    (notebook,) = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
+def test_notebook_2_with_all_backends():
+    [notebook] = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
     backends = []
     if "chainer" in collect_test_backends(symbolic=False, layers=True):
         backends += ["chainer"]
@@ -52,3 +52,17 @@ def test_dl_notebook_with_all_backends():
         expected_string = "selected {} backend".format(backend)
         result = render_notebook(notebook, replacements=replacements)
         assert expected_string in result
+
+
+def test_notebook_3():
+    [notebook] = Path(__file__).parent.with_name("docs").glob("3-*.ipynb")
+    if "pytorch" not in collect_test_backends(symbolic=False, layers=True):
+        pytest.skip()
+    render_notebook(notebook, replacements={})
+
+
+def test_notebook_4():
+    [notebook] = Path(__file__).parent.with_name("docs").glob("4-*.ipynb")
+    if "pytorch" not in collect_test_backends(symbolic=False, layers=True):
+        pytest.skip()
+    render_notebook(notebook, replacements={})

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from io import StringIO
 
-from tests import parse_backends_to_test
+from tests import parse_backends_to_test, is_backend_tested
 
 __author__ = "Alex Rogozhnikov"
 
@@ -39,7 +39,7 @@ def test_notebook_1():
 
 def test_notebook_2_with_all_backends():
     [notebook] = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
-    backends = ['chainer', 'torch', 'tensorflow']
+    backends = ["chainer", "torch", "tensorflow"]
     backends = [b for b in backends if b in parse_backends_to_test()]
     if len(backends) == 0:
         pytest.skip()
@@ -54,13 +54,13 @@ def test_notebook_2_with_all_backends():
 
 def test_notebook_3():
     [notebook] = Path(__file__).parent.with_name("docs").glob("3-*.ipynb")
-    if "torch" not in parse_backends_to_test():
+    if not is_backend_tested("torch"):
         pytest.skip()
     render_notebook(notebook, replacements={})
 
 
 def test_notebook_4():
     [notebook] = Path(__file__).parent.with_name("docs").glob("4-*.ipynb")
-    if "torch" not in parse_backends_to_test():
+    if not is_backend_tested("torch"):
         pytest.skip()
     render_notebook(notebook, replacements={})

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -4,7 +4,7 @@ from io import StringIO
 
 from tests import collect_test_backends
 
-__author__ = 'Alex Rogozhnikov'
+__author__ = "Alex Rogozhnikov"
 
 from pathlib import Path
 import nbformat
@@ -12,19 +12,19 @@ from nbconvert.preprocessors import ExecutePreprocessor
 
 
 def render_notebook(filename: Path, replacements: Dict[str, str]) -> str:
-    """ Takes path to the notebook, returns executed and rendered version
+    """Takes path to the notebook, returns executed and rendered version
     :param filename: notebook
     :param replacements: dictionary with text replacements done before executing
     :return: notebook, rendered as string
     """
-    with filename.open('r') as f:
+    with filename.open("r") as f:
         nb_as_str = f.read()
     for original, replacement in replacements.items():
         nb_as_str = nb_as_str.replace(original, replacement)
 
     nb = nbformat.read(StringIO(nb_as_str), nbformat.NO_CONVERT)
-    ep = ExecutePreprocessor(timeout=60, kernel_name='python3')
-    ep.preprocess(nb, {'metadata': {'path': str(filename.parent.absolute())}})
+    ep = ExecutePreprocessor(timeout=60, kernel_name="python3")
+    ep.preprocess(nb, {"metadata": {"path": str(filename.parent.absolute())}})
 
     result_as_stream = StringIO()
     nbformat.write(nb, result_as_stream)
@@ -32,19 +32,23 @@ def render_notebook(filename: Path, replacements: Dict[str, str]) -> str:
 
 
 def test_all_notebooks():
-    notebooks = Path(__file__).parent.with_name('docs').glob('*.ipynb')
+    notebooks = Path(__file__).parent.with_name("docs").glob("*.ipynb")
     for notebook in notebooks:
         render_notebook(notebook, replacements={})
 
 
 def test_dl_notebook_with_all_backends():
-    notebook, = Path(__file__).parent.with_name('docs').glob('2-*.ipynb')
-    backends = ['chainer', 'pytorch']
-    if 'tensorflow' in collect_test_backends(symbolic=False, layers=False):
-        backends += ['tensorflow']
+    (notebook,) = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
+    backends = []
+    if "chainer" in collect_test_backends(symbolic=False, layers=True):
+        backends += ["chainer"]
+    if "pytorch" in collect_test_backends(symbolic=False, layers=True):
+        backends += ["pytorch"]
+    if "tensorflow" in collect_test_backends(symbolic=False, layers=False):
+        backends += ["tensorflow"]
     for backend in backends:
-        print('Testing {} with backend {}'.format(notebook, backend))
+        print("Testing {} with backend {}".format(notebook, backend))
         replacements = {"flavour = 'pytorch'": "flavour = '{}'".format(backend)}
-        expected_string = 'selected {} backend'.format(backend)
+        expected_string = "selected {} backend".format(backend)
         result = render_notebook(notebook, replacements=replacements)
         assert expected_string in result

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -39,8 +39,15 @@ def test_notebook_1():
 
 def test_notebook_2_with_all_backends():
     [notebook] = Path(__file__).parent.with_name("docs").glob("2-*.ipynb")
-    backends = ["chainer", "torch", "tensorflow"]
-    backends = [b for b in backends if b in parse_backends_to_test()]
+    backends = []
+    if is_backend_tested("torch"):
+        # notebook uses name pytorch
+        backends.append("pytorch")
+    if is_backend_tested("tensorflow"):
+        backends.append("tensorflow")
+    if is_backend_tested("chainer"):
+        backends.append("chainer")
+
     if len(backends) == 0:
         pytest.skip()
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -274,7 +274,14 @@ def test_reduction_stress_imperatives():
             if reduction in ['mean', 'prod']:
                 dtype = 'float64'
                 coincide = numpy.allclose
-            for n_axes in range(6 if 'mxnet' in backend.framework_name else (7 if 'oneflow' in backend.framework_name else 11)):
+            max_dim = 11
+            if 'mxnet' in backend.framework_name:
+                max_dim = 6
+            if 'oneflow' in backend.framework_name:
+                max_dim = 7
+            if 'paddle' in backend.framework_name:
+                max_dim = 9
+            for n_axes in range(max_dim):
                 shape = numpy.random.randint(2, 4, size=n_axes)
                 permutation = numpy.random.permutation(n_axes)
                 skipped = 0 if reduction == 'rearrange' else numpy.random.randint(n_axes + 1)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -30,12 +30,11 @@ def test_backends_installed():
     This test will fail if some of backends are not installed or can't be imported
     Other tests will just work and only test installed backends.
     """
-    from . import skip_cupy, skip_oneflow
+    from . import parse_backends_to_test
+    backends_to_test = parse_backends_to_test()
     errors = []
     for backend_type in AbstractBackend.__subclasses__():
-        if skip_cupy and backend_type.framework_name == 'cupy':
-            continue
-        if skip_oneflow and backend_type.framework_name == 'oneflow':
+        if backend_type.framework_name not in backends_to_test:
             continue
         try:
             # instantiate

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -15,7 +15,7 @@ from einops._backends import AbstractBackend
 from einops.einops import rearrange, parse_shape, _optimize_transformation
 from . import collect_test_backends
 
-__author__ = 'Alex Rogozhnikov'
+__author__ = "Alex Rogozhnikov"
 
 
 def test_doctests_examples():
@@ -31,6 +31,7 @@ def test_backends_installed():
     Other tests will just work and only test installed backends.
     """
     from . import parse_backends_to_test
+
     backends_to_test = parse_backends_to_test()
     errors = []
     for backend_type in AbstractBackend.__subclasses__():
@@ -40,7 +41,7 @@ def test_backends_installed():
             # instantiate
             backend_type()
         except Exception as e:
-            if 'mxnet' in backend_type.framework_name:
+            if "mxnet" in backend_type.framework_name:
                 # test mxnet only if it is installed. Not complain if not installed
                 continue
             errors.append(e)
@@ -48,7 +49,7 @@ def test_backends_installed():
 
 
 def test_optimize_transformations_numpy():
-    print('Testing optimizations')
+    print("Testing optimizations")
     shapes = [[2] * n_dimensions for n_dimensions in range(14)]
     shapes += [[3] * n_dimensions for n_dimensions in range(6)]
     shapes += [[2, 3, 5, 7]]
@@ -57,15 +58,16 @@ def test_optimize_transformations_numpy():
     for shape in shapes:
         for attempt in range(5):
             n_dimensions = len(shape)
-            x = numpy.random.randint(0, 2 ** 12, size=shape).reshape([-1])
+            x = numpy.random.randint(0, 2**12, size=shape).reshape([-1])
             init_shape = shape[:]
             n_reduced = numpy.random.randint(0, n_dimensions + 1)
             reduced_axes = tuple(numpy.random.permutation(n_dimensions)[:n_reduced])
             axes_reordering = numpy.random.permutation(n_dimensions - n_reduced)
             final_shape = numpy.random.randint(0, 1024, size=333)  # just random
 
-            init_shape2, reduced_axes2, axes_reordering2, final_shape2 = combination2 = \
-                _optimize_transformation(init_shape, reduced_axes, axes_reordering, final_shape)
+            init_shape2, reduced_axes2, axes_reordering2, final_shape2 = combination2 = _optimize_transformation(
+                init_shape, reduced_axes, axes_reordering, final_shape
+            )
 
             assert numpy.array_equal(final_shape, final_shape2)
             result1 = x.reshape(init_shape).sum(axis=reduced_axes).transpose(axes_reordering).reshape([-1])
@@ -78,117 +80,136 @@ def test_optimize_transformations_numpy():
                 assert numpy.array_equal(a, b)
 
 
-_IMPERATIVE_BACKENDS = [{"backend": backend} for backend in
-                        (collect_test_backends(symbolic=False, layers=False) +
-                         collect_test_backends(symbolic=False, layers=True))]
+_IMPERATIVE_BACKENDS = [
+    {"backend": backend}
+    for backend in (
+        collect_test_backends(symbolic=False, layers=False) + collect_test_backends(symbolic=False, layers=True)
+    )
+]
 
 
 @parameterized_class(_IMPERATIVE_BACKENDS)
 class TestParseShapeImperative(unittest.TestCase):
+    backend: AbstractBackend
+
     def setUp(self):
         self.x = numpy.zeros([10, 20, 30, 40])
 
     def test_parse_shape_imperative(self):
-        print('Shape parsing for ', self.backend.framework_name)
-        parsed1 = parse_shape(self.x, 'a b c d')
-        parsed2 = parse_shape(self.backend.from_numpy(self.x), 'a b c d')
+        print("Shape parsing for ", self.backend.framework_name)
+        parsed1 = parse_shape(self.x, "a b c d")
+        parsed2 = parse_shape(self.backend.from_numpy(self.x), "a b c d")
         assert parsed1 == parsed2 == dict(a=10, b=20, c=30, d=40)
         assert parsed1 != dict(a=1, b=20, c=30, d=40) != parsed2
 
     def test_underscore(self):
-        parsed1 = parse_shape(self.x, '_ _ _ _')
-        parsed2 = parse_shape(self.backend.from_numpy(self.x), '_ _ _ _')
+        parsed1 = parse_shape(self.x, "_ _ _ _")
+        parsed2 = parse_shape(self.backend.from_numpy(self.x), "_ _ _ _")
         assert parsed1 == parsed2 == dict()
 
     def test_underscore_one(self):
-        parsed1 = parse_shape(self.x, '_ _ _ hello')
-        parsed2 = parse_shape(self.backend.from_numpy(self.x), '_ _ _ hello')
+        parsed1 = parse_shape(self.x, "_ _ _ hello")
+        parsed2 = parse_shape(self.backend.from_numpy(self.x), "_ _ _ hello")
         assert parsed1 == parsed2 == dict(hello=40)
 
     def test_underscore_several(self):
-        parsed1 = parse_shape(self.x, '_ _ a1 a1a111a')
-        parsed2 = parse_shape(self.backend.from_numpy(self.x), '_ _ a1 a1a111a')
+        parsed1 = parse_shape(self.x, "_ _ a1 a1a111a")
+        parsed2 = parse_shape(self.backend.from_numpy(self.x), "_ _ a1 a1a111a")
         assert parsed1 == parsed2 == dict(a1=30, a1a111a=40)
 
     def test_repeating(self):
         with pytest.raises(einops.EinopsError):
-            parse_shape(self.x, 'a a b b')
+            parse_shape(self.x, "a a b b")
 
         with pytest.raises(einops.EinopsError):
-            parse_shape(self.backend.from_numpy(self.x), 'a a b b')
+            parse_shape(self.backend.from_numpy(self.x), "a a b b")
 
-    @parameterized.expand([
-        ([10, 20], '...', dict()),
-        ([10], '... a', dict(a=10)),
-        ([10, 20], '... a', dict(a=20)),
-        ([10, 20, 30], '... a', dict(a=30)),
-        ([10, 20, 30, 40], '... a', dict(a=40)),
-        ([10], 'a ...', dict(a=10)),
-        ([10, 20], 'a ...', dict(a=10)),
-        ([10, 20, 30], 'a ...', dict(a=10)),
-        ([10, 20, 30, 40], 'a ...', dict(a=10)),
-        ([10, 20, 30, 40], ' a ... b', dict(a=10, b=40)),
-        ([10, 40], ' a ... b', dict(a=10, b=40)),
-    ])
-    def test_ellipsis(self, shape: List[int], pattern: str,
-                      expected: Dict[str, int]):
+    @parameterized.expand(
+        [
+            ([10, 20], "...", dict()),
+            ([10], "... a", dict(a=10)),
+            ([10, 20], "... a", dict(a=20)),
+            ([10, 20, 30], "... a", dict(a=30)),
+            ([10, 20, 30, 40], "... a", dict(a=40)),
+            ([10], "a ...", dict(a=10)),
+            ([10, 20], "a ...", dict(a=10)),
+            ([10, 20, 30], "a ...", dict(a=10)),
+            ([10, 20, 30, 40], "a ...", dict(a=10)),
+            ([10, 20, 30, 40], " a ... b", dict(a=10, b=40)),
+            ([10, 40], " a ... b", dict(a=10, b=40)),
+        ]
+    )
+    def test_ellipsis(self, shape: List[int], pattern: str, expected: Dict[str, int]):
         x = numpy.ones(shape)
         parsed1 = parse_shape(x, pattern)
         parsed2 = parse_shape(self.backend.from_numpy(x), pattern)
         assert parsed1 == parsed2 == expected
 
 
-_SYMBOLIC_BACKENDS = [{"backend": backend} for backend in
-                      (collect_test_backends(symbolic=True, layers=False) +
-                       collect_test_backends(symbolic=True, layers=True))
-                      if backend.framework_name != 'tensorflow.keras']
+_SYMBOLIC_BACKENDS = [
+    {"backend": backend}
+    for backend in (
+        collect_test_backends(symbolic=True, layers=False) + collect_test_backends(symbolic=True, layers=True)
+    )
+    if backend.framework_name != "tensorflow.keras"
+]
 # tensorflow.keras needs special way to compile,
 # shape vars can be used only inside layers but not as outputs
 
 
 @parameterized_class(_SYMBOLIC_BACKENDS)
 class TestParseShapeSymbolic(unittest.TestCase):
-    @parameterized.expand([
-        ([10, 20, 30, 40],),
-        ([10, 20, None, None],),
-        ([None, None, None, None],),
-    ])
+    backend: AbstractBackend
+    @parameterized.expand(
+        [
+            ([10, 20, 30, 40],),
+            ([10, 20, None, None],),
+            ([None, None, None, None],),
+        ]
+    )
     def test_parse_shape_symbolic(self, shape):
-        print('special shape parsing for', self.backend.framework_name)
-        if self.backend.framework_name in ['mxnet.symbol']:
+        print("special shape parsing for", self.backend.framework_name)
+        if self.backend.framework_name in ["mxnet.symbol"]:
             # mxnet can't normally run inference
             shape = [10, 20, 30, 40]
         input_symbol = self.backend.create_symbol(shape)
 
-        shape_placeholder = parse_shape(input_symbol, 'a b c d')
+        shape_placeholder = parse_shape(input_symbol, "a b c d")
         shape = {}
         for name, symbol in shape_placeholder.items():
-            shape[name] = symbol if isinstance(symbol, int) \
+            shape[name] = (
+                symbol
+                if isinstance(symbol, int)
                 else self.backend.eval_symbol(symbol, [(input_symbol, numpy.zeros([10, 20, 30, 40]))])
+            )
         print(shape)
-        result_placeholder = rearrange(input_symbol, 'a b (c1 c2) (d1 d2) -> (a b d1) c1 (c2 d2)',
-                                       **parse_shape(input_symbol, 'a b c1 _'), d2=2)
+        result_placeholder = rearrange(
+            input_symbol, "a b (c1 c2) (d1 d2) -> (a b d1) c1 (c2 d2)", **parse_shape(input_symbol, "a b c1 _"), d2=2
+        )
         result = self.backend.eval_symbol(result_placeholder, [(input_symbol, numpy.zeros([10, 20, 30, 40]))])
         print(result.shape)
         assert result.shape == (10 * 20 * 20, 30, 1 * 2)
         assert numpy.allclose(result, 0)
 
-    @parameterized.expand([
-        ([10, 20], [None, None], '...', dict()),
-        ([10], [None], '... a', dict(a=10)),
-        ([10, 20], [None], '... a', dict(a=20)),
-        ([10, 20, 30], [None, None, None], '... a', dict(a=30)),
-        ([10, 20, 30, 40], [None, None, None, None], '... a', dict(a=40)),
-        ([10], [None], 'a ...', dict(a=10)),
-        ([10, 20], [None, None], 'a ...', dict(a=10)),
-        ([10, 20, 30], [None, None, None], 'a ...', dict(a=10)),
-        ([10, 20, 30, 40], [None, None, None, None], 'a ...', dict(a=10)),
-        ([10, 20, 30, 40], [None, None, None, None], ' a ... b', dict(a=10, b=40)),
-        ([10, 40], [None, None], ' a ... b', dict(a=10, b=40)),
-    ])
-    def test_ellipsis(self, static_shape: List[int], shape: List[Optional[int]],
-                      pattern: str, expected: Dict[str, int]):
-        if self.backend.framework_name in ['mxnet.symbol']:
+    @parameterized.expand(
+        [
+            ([10, 20], [None, None], "...", dict()),
+            ([10], [None], "... a", dict(a=10)),
+            ([10, 20], [None], "... a", dict(a=20)),
+            ([10, 20, 30], [None, None, None], "... a", dict(a=30)),
+            ([10, 20, 30, 40], [None, None, None, None], "... a", dict(a=40)),
+            ([10], [None], "a ...", dict(a=10)),
+            ([10, 20], [None, None], "a ...", dict(a=10)),
+            ([10, 20, 30], [None, None, None], "a ...", dict(a=10)),
+            ([10, 20, 30, 40], [None, None, None, None], "a ...", dict(a=10)),
+            ([10, 20, 30, 40], [None, None, None, None], " a ... b", dict(a=10, b=40)),
+            ([10, 40], [None, None], " a ... b", dict(a=10, b=40)),
+        ]
+    )
+    def test_ellipsis(
+        self, static_shape: List[int], shape: List[Optional[int]], pattern: str, expected: Dict[str, int]
+    ):
+        if self.backend.framework_name in ["mxnet.symbol"]:
             # mxnet can't normally run inference
             shape = static_shape
         input_symbol = self.backend.create_symbol(shape)
@@ -198,8 +219,7 @@ class TestParseShapeSymbolic(unittest.TestCase):
             if isinstance(symbol, int):
                 out_shape[name] = symbol
             else:
-                out_shape[name] = self.backend.eval_symbol(
-                    symbol, [(input_symbol, numpy.zeros(static_shape))])
+                out_shape[name] = self.backend.eval_symbol(symbol, [(input_symbol, numpy.zeros(static_shape))])
         assert out_shape == expected
 
 
@@ -207,10 +227,10 @@ def test_is_float_type():
     backends = collect_test_backends(symbolic=False, layers=False)
     backends += collect_test_backends(symbolic=False, layers=True)
     for backend in backends:
-        for dtype in ['int32', 'int64', 'float32', 'float64']:
-            is_float = 'float' in dtype
+        for dtype in ["int32", "int64", "float32", "float64"]:
+            is_float = "float" in dtype
             input = numpy.zeros([3, 4, 5], dtype=dtype)
             input = backend.from_numpy(input)
-            if 'chainer' in backend.framework_name and not is_float:
+            if "chainer" in backend.framework_name and not is_float:
                 continue  # chainer doesn't allow non-floating tensors
             assert backend.is_float_type(input) == is_float, (dtype, backend, input.dtype)


### PR DESCRIPTION
- backend for paddle was added

- testing now can specify which frameworks to test, and tests have simpler utilties
- started adopting black + pylance for style/type warnings
- multiple tests now depend on backend being tested
- in CI frameworks are split into two groups because of protobuf conflicts