### PR TITLE
automatically register torch ops in torchdynamo

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -217,6 +217,8 @@ class TorchBackend(AbstractBackend):
         import torch
 
         self.torch = torch
+        # importing would register operations in torch._dynamo for torch.compile
+        from . import _torch_specific  # noqa
 
     def is_appropriate_type(self, tensor):
         return isinstance(tensor, self.torch.Tensor)


### PR DESCRIPTION
registration happens in either of cases:


1. explicit import of _torch_specific
1. einops operation is used on torch tensor (this triggers instantiation of TorchBackend which imports _torch_specific)
1. usage of any torch layer