### PR TITLE
Wrap torch symbolic shape as HashableTuple to mitigate unhashable torch.SymInt

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -252,6 +252,15 @@ class TorchBackend(AbstractBackend):
         else:
             raise NotImplementedError("Unknown reduction ", operation)
 
+    def shape(self, x):
+        shape = x.shape
+        try:
+            hash(shape)
+            return shape
+        except:
+            # unhashable symbols in shape. Wrap tuple to be hashable.
+            return HashableTuple(shape)
+
     def transpose(self, x, axes):
         return x.permute(axes)
 

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -233,7 +233,7 @@ def _apply_recipe(
     # disable cache during torch symbolic tracing because torch.SymInt is not hashable
     if (
         backend.framework_name == 'torch'
-        and backend.torch.torch_version.TorchVersion(backend.torch.__version__) > '2.0.1'
+        and hasattr(torch.fx.experimental.symbolic_shapes, "free_symbols")
         and len(backend.torch.fx.experimental.symbolic_shapes.free_symbols(shape)) > 0
     ):
         reconstruct_fn = _reconstruct_from_shape_uncached

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -231,7 +231,11 @@ def _apply_recipe(
 ) -> Tensor:
     shape = backend.shape(tensor)
     # disable cache during torch symbolic tracing because torch.SymInt is not hashable
-    if backend.framework_name == 'torch' and len(backend.torch.fx.experimental.symbolic_shapes.free_symbols(shape)) > 0:
+    if (
+        backend.framework_name == 'torch'
+        and backend.torch.torch_version.TorchVersion(backend.torch.__version__) > '2.0.1'
+        and len(backend.torch.fx.experimental.symbolic_shapes.free_symbols(shape)) > 0
+    ):
         reconstruct_fn = _reconstruct_from_shape_uncached
     else:
         reconstruct_fn = _reconstruct_from_shape

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -233,7 +233,7 @@ def _apply_recipe(
     # disable cache during torch symbolic tracing because torch.SymInt is not hashable
     if (
         backend.framework_name == 'torch'
-        and hasattr(torch.fx.experimental.symbolic_shapes, "free_symbols")
+        and hasattr(backend.torch.fx.experimental.symbolic_shapes, "free_symbols")
         and len(backend.torch.fx.experimental.symbolic_shapes.free_symbols(shape)) > 0
     ):
         reconstruct_fn = _reconstruct_from_shape_uncached

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -229,9 +229,15 @@ _reconstruct_from_shape = functools.lru_cache(1024)(_reconstruct_from_shape_unca
 def _apply_recipe(
     backend, recipe: TransformRecipe, tensor: Tensor, reduction_type: Reduction, axes_lengths: HashableAxesLengths
 ) -> Tensor:
+    shape = backend.shape(tensor)
+    # disable cache during torch symbolic tracing because torch.SymInt is not hashable
+    if backend.framework_name == 'torch' and len(backend.torch.fx.experimental.symbolic_shapes.free_symbols(shape)) > 0:
+        reconstruct_fn = _reconstruct_from_shape_uncached
+    else:
+        reconstruct_fn = _reconstruct_from_shape
     # this method implements actual work for all backends for 3 operations
-    init_shapes, axes_reordering, reduced_axes, added_axes, final_shapes, n_axes_w_added = _reconstruct_from_shape(
-        recipe, backend.shape(tensor), axes_lengths
+    init_shapes, axes_reordering, reduced_axes, added_axes, final_shapes, n_axes_w_added = reconstruct_fn(
+        recipe, shape, axes_lengths
     )
     if init_shapes is not None:
         tensor = backend.reshape(tensor, init_shapes)


### PR DESCRIPTION
This is a potential fix for https://github.com/pytorch/pytorch/issues/93905 and https://github.com/pytorch/pytorch/issues/105686.