### PR TITLE
Coerce bool to int in unpack

### DIFF
--- a/einops/packing.py
+++ b/einops/packing.py
@@ -150,7 +150,7 @@ def unpack(tensor: Tensor, packed_shapes: List[Shape], pattern: str) -> List[Ten
         for p_shape in packed_shapes
     ]
 
-    n_unknown_composed_axes = sum(x == -1 for x in lengths_of_composed_axes)
+    n_unknown_composed_axes = sum(int(x == -1) for x in lengths_of_composed_axes)
     if n_unknown_composed_axes > 1:
         raise EinopsError(
             f"unpack(..., {pattern}) received more than one -1 in {packed_shapes} and can't infer dimensions"


### PR DESCRIPTION
While trying to use torch.compile with `backend=inductor` for a model that uses unpack as 
```
unpack(x, ps, "b d *")[0]
```

I received the error 

```
torch._dynamo.exc.TorchRuntimeError: Failed running call_function <function unpack at 0x7f5c30806200>(*(FakeTensor(..., device='cuda:0', size=(1, 128, (s1//2))), [((s1//2),)], 'b d *'), **{}):
unsupported operand type(s) for +: 'int' and 'SymBool'
```

tracing back to the line changed in this PR. Coercing the boolean to an int so `sum` does not try to sum a boolean and an int fixed my issue locally.