### PR TITLE
Fix invalid escape sequence in einsum docstring

### DIFF
--- a/einops/einops.py
+++ b/einops/einops.py
@@ -824,7 +824,7 @@ def einsum(tensor1: Tensor, tensor2: Tensor, tensor3: Tensor, tensor4: Tensor, p
 
 
 def einsum(*tensors_and_pattern: Union[Tensor, str]) -> Tensor:
-    """
+    r"""
     einops.einsum calls einsum operations with einops-style named
     axes indexing, computing tensor products with an arbitrary
     number of tensors. Unlike typical einsum syntax, here you must


### PR DESCRIPTION
Current einsum docstring has an invalid escape sequence, specifically in the `\sum` for some LaTeX code. This can be checked by running the following:

```bash
$ PYTHONWARNINGS=error python -c "import einops"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "~/.venv/lib/python3.10/site-packages/einops/__init__.py", line 14, in <module>
    from .einops import rearrange, reduce, repeat, einsum, parse_shape, asnumpy
  File "~/.venv/lib/python3.10/site-packages/einops/einops.py", line 827
    """
    ^^^
SyntaxError: invalid escape sequence '\s'
```

This can be annoying, especially when running tests if one wants to run them in strict mode (warnings-as-errors) Replacing with a raw docstring removes the issue.