### PR TITLE
issues related to paddle have been fixed in paddle nightly build, update settings here

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,8 +13,7 @@ jobs:
         # cupy is not tested because it demands gpu
         # oneflow testing is dropped, see details at https://github.com/Oneflow-Inc/oneflow/issues/10340
         # chainer testing is dropped because of conflict with numpy 2.0, see https://github.com/chainer/chainer/issues/8632
-        # paddle was switched off because of divergence with numpy in py3.10, paddle==2.6.1
-        frameworks: ['numpy pytorch tensorflow jax']
+        frameworks: ['numpy pytorch tensorflow jax', 'numpy paddle']
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,5 +104,7 @@ cache-dir = "/tmp/ruff_cache" # move cache out of workdir
 
 lint.select = ["E4", "E7", "E9", "F", "W"]
 
+extend-exclude = ["*.ipynb"]
+
 [tool.ruff.format]
 docstring-code-format = false

--- a/test.py
+++ b/test.py
@@ -40,9 +40,8 @@ def main():
         "tensorflow": ["tensorflow"],
         "chainer": ["chainer"],
         "cupy": ["cupy"],
-        # switch to stable paddlepaddle, because of https://github.com/PaddlePaddle/Paddle/issues/63927
-        # "paddle": ["paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html"],
-        "paddle": ["paddlepaddle"],
+        "paddle": ["--pre paddlepaddle -i https://www.paddlepaddle.org.cn/packages/nightly/cpu/"],
+        # "paddle": ["paddlepaddle"],
         "oneflow": ["oneflow==0.9.0"],
     }
 


### PR DESCRIPTION
- https://github.com/PaddlePaddle/Paddle/issues/63927 has been fixed by https://github.com/PaddlePaddle/Paddle/pull/67588, so it's possible to use nightly build now.
- paddle has established a dedicated pypi index repository, updated the command for install paddlepaddle nightly build.

- explicitly exclude Jupyter Notebook in ruff configuration. Since [ruff 0.6.0](https://github.com/astral-sh/ruff/releases/tag/0.6.0), ruff will lint and format Jupyter Notebook by default, this behavior will cause docs/*.ipynb failed in ruff >= 0.6.0 setting. Probably we can fix these linting errors in separated PR.