### PR TITLE
Fix tensor concat in tinygrad backend

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -706,7 +706,7 @@ class TinygradBackend(AbstractBackend):
         return x.repeat(repeats)
 
     def concat(self, tensors, axis: int):
-        return tensors[0].cat(tensors[1:], axis) if len(tensors) > 1 else tensors[0]
+        return tensors[0].cat(*tensors[1:], dim=axis) if len(tensors) > 1 else tensors[0]
 
     def is_float_type(self, x):
         return self.tinygrad.dtypes.is_float(x.dtype)


### PR DESCRIPTION
Pass tensors to `Tensor.cat` by `*args` instead of a list in tinygrad backend

The `Tensor.cat` in tinygrad backend takes tensors from `*args` instead of a list of tensor (https://github.com/tinygrad/tinygrad/blob/774bf39f85685aa55196b2716fa27f36d0dc88ba/tinygrad/tensor.py#L1091)