### PR TITLE
Add devcontainer and dockerfile

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
         "--name=einops-devbox",
     ],
     "shutdownAction": "none",
-    "postCreateCommand": "pip install uv && uv pip install --system pre-commit -e . && pre-commit install -f",
+    "postCreateCommand": "uv pip install --system -e . && pre-commit install -f",
     "customizations": {
         "vscode": {
             "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+    "name": "EinopsDev",
+    "build": {
+        "context": "..",
+        "dockerfile": "./einops.Dockerfile",
+        "target": "einops-devimage",
+    },
+    "runArgs": [
+        // to use GPUs in container uncomment next line
+        // "--gpus=all",
+        "--name=einops-devbox",
+    ],
+    "shutdownAction": "none",
+    "postCreateCommand": "pip install uv && uv pip install --system pre-commit -e . && pre-commit install -f",
+    "customizations": {
+        "vscode": {
+            "settings": {
+                "python.defaultInterpreterPath": "/opt/venv/bin/python"
+            },
+            "extensions": [
+                "ms-azuretools.vscode-docker",
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "ms-python.mypy-type-checker",
+                "charliermarsh.ruff",
+                "ms-toolsai.jupyter",
+                // very optional git-specific stuff
+                "arturock.gitstash",
+                "mhutchie.git-graph",
+            ]
+        }
+    }
+}

--- a/.devcontainer/einops.Dockerfile
+++ b/.devcontainer/einops.Dockerfile
@@ -1,2 +1,4 @@
 FROM python:3.11-bookworm AS einops-devimage
 # note this will pull aarch64 or x86 depending on machine it is running on.
+RUN pip install uv \
+ && uv pip install --system pre-commit hatch

--- a/.devcontainer/einops.Dockerfile
+++ b/.devcontainer/einops.Dockerfile
@@ -1,0 +1,2 @@
+FROM python:3.11-bookworm AS einops-devimage
+# note this will pull aarch64 or x86 depending on machine it is running on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
     "mkdocs-jupyter~=0.22.0",
     # required by codehilite (highlithing in mkdocs)
     "pygments~=2.13.0",
+    "lxml[html_clean]",
 ]
 [tool.hatch.envs.docs.scripts]
 # For examples to build one has to run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,10 +77,6 @@ deploy_test = "hatch build --clean && hatch publish -r test"
 deploy = "hatch build --clean && hatch publish"
 
 
-[tool.hatch.envs.testing.scripts]
-# hatch run testing:test
-test = "python test.py"
-
 
 [tool.pytest.ini_options]
 # suppressing irrelevant warnings from google's tensorflow and pb2 on m1 mac


### PR DESCRIPTION
motivation: 

fastest way to have ~isolated environment that is ~compatible to CI and has pre-commits turned on by default.

Confirmed this works right from github interface:

```shell
python test.py numpy
hatch run docs:build
```

fix #328 
