### PR TITLE
Add dict syntax to the einops layers example

### DIFF
--- a/docs/2-einops-for-deep-learning.ipynb
+++ b/docs/2-einops-for-deep-learning.ipynb
@@ -1162,7 +1162,7 @@
     "    ReLU(),\n",
     "    Linear(120, 10), \n",
     "    # In flax, the {'axis': value} syntax for specifying values for axes is mandatory:\n",
-    "    Rearrange('(b1 b2) d -> b1 b2 d', {'b1': 12}), \n",
+    "    # Rearrange('(b1 b2) d -> b1 b2 d', {'b1': 12}), \n",
     ")\n",
     "```"
    ]

--- a/docs/2-einops-for-deep-learning.ipynb
+++ b/docs/2-einops-for-deep-learning.ipynb
@@ -1149,7 +1149,6 @@
     "Usually it is more convenient to use layers, not operations, to build models\n",
     "```python\n",
     "# example given for pytorch, but code in other frameworks is almost identical\n",
-    "# Note: {axis: value} syntax have to be used in flax for specifying values for axes\n",
     "from torch.nn import Sequential, Conv2d, MaxPool2d, Linear, ReLU\n",
     "from einops.layers.torch import Reduce\n",
     "\n",
@@ -1162,7 +1161,7 @@
     "    Linear(16*5*5, 120), \n",
     "    ReLU(),\n",
     "    Linear(120, 10), \n",
-    "    # In flax, the {'axis': value} syntax for specifying values for axes is mandatory\n",
+    "    # In flax, the {'axis': value} syntax for specifying values for axes is mandatory:\n",
     "    Rearrange('(b1 b2) d -> b1 b2 d', {'b1': 12}), \n",
     ")\n",
     "```"

--- a/docs/2-einops-for-deep-learning.ipynb
+++ b/docs/2-einops-for-deep-learning.ipynb
@@ -1149,6 +1149,7 @@
     "Usually it is more convenient to use layers, not operations, to build models\n",
     "```python\n",
     "# example given for pytorch, but code in other frameworks is almost identical\n",
+    "# note the {axis: value} syntax used for specifying values for axes\n",
     "from torch.nn import Sequential, Conv2d, MaxPool2d, Linear, ReLU\n",
     "from einops.layers.torch import Reduce\n",
     "\n",
@@ -1161,6 +1162,8 @@
     "    Linear(16*5*5, 120), \n",
     "    ReLU(),\n",
     "    Linear(120, 10), \n",
+    "    # use {'axis': value} for specifying values for axes\n",
+    "    Rearrange('(b1 b2) d -> b1 b2 d', {'b1': 12}), \n",
     ")\n",
     "```"
    ]

--- a/docs/2-einops-for-deep-learning.ipynb
+++ b/docs/2-einops-for-deep-learning.ipynb
@@ -1149,7 +1149,7 @@
     "Usually it is more convenient to use layers, not operations, to build models\n",
     "```python\n",
     "# example given for pytorch, but code in other frameworks is almost identical\n",
-    "# note the {axis: value} syntax used for specifying values for axes\n",
+    "# Note: {axis: value} syntax have to be used in flax for specifying values for axes\n",
     "from torch.nn import Sequential, Conv2d, MaxPool2d, Linear, ReLU\n",
     "from einops.layers.torch import Reduce\n",
     "\n",
@@ -1162,7 +1162,7 @@
     "    Linear(16*5*5, 120), \n",
     "    ReLU(),\n",
     "    Linear(120, 10), \n",
-    "    # use {'axis': value} for specifying values for axes\n",
+    "    # In flax, the {'axis': value} syntax for specifying values for axes is mandatory\n",
     "    Rearrange('(b1 b2) d -> b1 b2 d', {'b1': 12}), \n",
     ")\n",
     "```"


### PR DESCRIPTION
This patch adds an example of the dict syntax that is given as argument in einops layers.

**Why do we need this change?**
I was trying to make an einops layer doing the following rearrange:
```python
Rearrange('b (h w c) -> b h w c', h=64, w=64)
```
And had to read the source code to discover I have to use dict syntax to make it works:
```python
Rearrange('b (h w c) -> b h w c', {'h'=64, 'w'=64})
```

So I believe that adding this example to the docs will make it easier for people like me