### PR TITLE
include CITATION.cff for einops

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ preferred-citation:
   authors:
   - given-names: Alex
     family-names: Rogozhnikov
-  journal: "Internaltional Conference on Learning Representations"
+  journal: "International Conference on Learning Representations"
   title: "Einops: Clear and Reliable Tensor Manipulations with Einstein-like Notation"
   year: 2022
   url: https://openreview.net/forum?id=oapKSVM2bc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+title: einops
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - given-names: Alex
+    family-names: Rogozhnikov
+repository-code: 'https://github.com/arogozhnikov/einops'
+abstract: >-
+  Flexible and powerful tensor operations for readable and reliable code (for pytorch, jax, TF and others)
+license: MIT
+preferred-citation:
+  type: article
+  authors:
+  - given-names: Alex
+    family-names: Rogozhnikov
+  journal: "Internaltional Conference on Learning Representations"
+  title: "Einops: Clear and Reliable Tensor Manipulations with Einstein-like Notation"
+  year: 2022
+  url: https://openreview.net/forum?id=oapKSVM2bc


### PR DESCRIPTION
Adding a CITATION.cff enables GitHub and other apps to automatically detect the correct way to cite mlx. This file contains the same semantic content as the BibTex citation in the README. You can take a look at how other repos implement their CITATION.cff for more info, like [pytorch/CITATION.cff](https://github.com/pytorch/pytorch/blob/main/CITATION.cff)

It also adds new views on the GitHub site, for example:

<img width="551" alt="Screenshot 2024-10-13 at 1 11 17 PM" src="https://github.com/user-attachments/assets/63482af1-06a7-4a5e-8399-c9d4cf69fdf2">

