### PR TITLE
Fix docs broken links after `master` -> `main` migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://user-images.githubusercontent.com/6318811/177030658-66f0eb5d-e136-44d8-9
 [![Run tests](https://github.com/arogozhnikov/einops/actions/workflows/run_tests.yml/badge.svg)](https://github.com/arogozhnikov/einops/actions/workflows/run_tests.yml)
 [![PyPI version](https://badge.fury.io/py/einops.svg)](https://badge.fury.io/py/einops)
 [![Documentation](https://img.shields.io/badge/documentation-link-blue.svg)](https://einops.rocks/)
-![Supported python versions](https://raw.githubusercontent.com/arogozhnikov/einops/master/docs/resources/python_badge.svg)
+![Supported python versions](https://raw.githubusercontent.com/arogozhnikov/einops/main/docs/resources/python_badge.svg)
 
 
 Flexible and powerful tensor operations for readable and reliable code. <br />
@@ -33,7 +33,7 @@ Supports numpy, pytorch, tensorflow, jax, and [others](#supported-frameworks).
 - 0.7.0: no-hassle `torch.compile`, support of [array api standard](https://data-apis.org/array-api/latest/API_specification/index.html) and more
 - 10'000🎉: github reports that more than 10k project use einops
 - einops 0.6.1: paddle backend added
-- einops 0.6 introduces [packing and unpacking](https://github.com/arogozhnikov/einops/blob/master/docs/4-pack-and-unpack.ipynb)
+- einops 0.6 introduces [packing and unpacking](https://github.com/arogozhnikov/einops/blob/main/docs/4-pack-and-unpack.ipynb)
 - einops 0.5: einsum is now a part of einops
 - [Einops paper](https://openreview.net/pdf?id=oapKSVM2bcj) is accepted for oral presentation at ICLR 2022 (yes, it worth reading).
   Talk recordings are [available](https://iclr.cc/virtual/2022/oral/6603)
@@ -43,7 +43,7 @@ Supports numpy, pytorch, tensorflow, jax, and [others](#supported-frameworks).
 <summary>Previous updates</summary>
 - flax and oneflow backend added
 - torch.jit.script is supported for pytorch layers
-- powerful EinMix added to einops. [Einmix tutorial notebook](https://github.com/arogozhnikov/einops/blob/master/docs/3-einmix-layer.ipynb) 
+- powerful EinMix added to einops. [Einmix tutorial notebook](https://github.com/arogozhnikov/einops/blob/main/docs/3-einmix-layer.ipynb) 
 </details>
 
 <!--<div align="center">
@@ -89,9 +89,9 @@ pip install einops
 
 Tutorials are the most convenient way to see `einops` in action
 
-- part 1: [einops fundamentals](https://github.com/arogozhnikov/einops/blob/master/docs/1-einops-basics.ipynb)
-- part 2: [einops for deep learning](https://github.com/arogozhnikov/einops/blob/master/docs/2-einops-for-deep-learning.ipynb)
-- part 3: [packing and unpacking](https://github.com/arogozhnikov/einops/blob/master/docs/4-pack-and-unpack.ipynb)
+- part 1: [einops fundamentals](https://github.com/arogozhnikov/einops/blob/main/docs/1-einops-basics.ipynb)
+- part 2: [einops for deep learning](https://github.com/arogozhnikov/einops/blob/main/docs/2-einops-for-deep-learning.ipynb)
+- part 3: [packing and unpacking](https://github.com/arogozhnikov/einops/blob/main/docs/4-pack-and-unpack.ipynb)
 - part 4: [improve pytorch code with einops](http://einops.rocks/pytorch-examples.html)
 
 Kapil Sachdeva recorded a small [intro to einops](https://www.youtube.com/watch?v=xGy75Pjsqzo).
@@ -100,7 +100,7 @@ Kapil Sachdeva recorded a small [intro to einops](https://www.youtube.com/watch?
 
 `einops` has a minimalistic yet powerful API.
 
-Three core operations provided ([einops tutorial](https://github.com/arogozhnikov/einops/blob/master/docs/)
+Three core operations provided ([einops tutorial](https://github.com/arogozhnikov/einops/blob/main/docs/)
 shows those cover stacking, reshape, transposition, squeeze/unsqueeze, repeat, tile, concatenate, view and numerous reductions)
 
 ```python

--- a/docs/1-einops-basics.ipynb
+++ b/docs/1-einops-basics.ipynb
@@ -1301,7 +1301,7 @@
     "\n",
     "\n",
     "\n",
-    "- [Second part of tutorial](https://github.com/arogozhnikov/einops/tree/master/docs) shows how einops works with other frameworks\n",
+    "- [Second part of tutorial](https://github.com/arogozhnikov/einops/tree/main/docs) shows how einops works with other frameworks\n",
     "- [Third part of tutorial](https://arogozhnikov.github.io/einops/pytorch-examples.html) shows how to improve your DL code with einops"
    ]
   }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ You can read notebooks from github by clicking on files above.
 
 If you prefer nbviewer, use the links below:
 
-- Part 1 notebook at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/master/docs/1-einops-basics.ipynb)
-- Part 2 notebook at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/master/docs/2-einops-for-deep-learning.ipynb)
-- Part 3: EinMix for great MLPs at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/master/docs/3-einmix-layer.ipynb)
-- Part 4: einops.pack and einops.unpack [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/master/docs/4-pack-and-unpack.ipynb)
+- Part 1 notebook at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/main/docs/1-einops-basics.ipynb)
+- Part 2 notebook at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/main/docs/2-einops-for-deep-learning.ipynb)
+- Part 3: EinMix for great MLPs at [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/main/docs/3-einmix-layer.ipynb)
+- Part 4: einops.pack and einops.unpack [nbviewer](https://nbviewer.jupyter.org/github/arogozhnikov/einops/blob/main/docs/4-pack-and-unpack.ipynb)
 - Writing better code with einops and pytorch: [web link](https://einops.rocks/pytorch-examples.html)
  

--- a/docs/pytorch-examples.html
+++ b/docs/pytorch-examples.html
@@ -127,8 +127,8 @@
     <div>
     <a href="https://github.com/arogozhnikov/einops">[github]</a>, &nbsp;&nbsp;
     tutorials
-    <a href="https://github.com/arogozhnikov/einops/blob/master/docs/1-einops-basics.ipynb">[1]</a> and 
-    <a href="https://github.com/arogozhnikov/einops/blob/master/docs/2-einops-for-deep-learning.ipynb">[2]</a>    
+    <a href="https://github.com/arogozhnikov/einops/blob/main/docs/1-einops-basics.ipynb">[1]</a> and
+    <a href="https://github.com/arogozhnikov/einops/blob/main/docs/2-einops-for-deep-learning.ipynb">[2]</a>
     <br />
     <br />
     </div>

--- a/einops/layers/_einmix.py
+++ b/einops/layers/_einmix.py
@@ -18,7 +18,7 @@ class _EinmixMixin:
         EinMix - Einstein summation with automated tensor management and axis packing/unpacking.
 
         EinMix is an advanced tool, helpful tutorial:
-        https://github.com/arogozhnikov/einops/blob/master/docs/3-einmix-layer.ipynb
+        https://github.com/arogozhnikov/einops/blob/main/docs/3-einmix-layer.ipynb
 
         Imagine taking einsum with two arguments, one of each input, and one - tensor with weights
         >>> einsum('time batch channel_in, channel_in channel_out -> time batch channel_out', input, weight)

--- a/scripts/pytorch_examples_source/Pytorch.ipynb
+++ b/scripts/pytorch_examples_source/Pytorch.ipynb
@@ -11,8 +11,8 @@
     "    <div>\n",
     "    <a href=\"https://github.com/arogozhnikov/einops\">[github]</a>, &nbsp;&nbsp;\n",
     "    tutorials\n",
-    "    <a href=\"https://github.com/arogozhnikov/einops/blob/master/docs/1-einops-basics.ipynb\">[1]</a> and \n",
-    "    <a href=\"https://github.com/arogozhnikov/einops/blob/master/docs/2-einops-for-deep-learning.ipynb\">[2]</a>    \n",
+    "    <a href=\"https://github.com/arogozhnikov/einops/blob/main/docs/1-einops-basics.ipynb\">[1]</a> and\n",
+    "    <a href=\"https://github.com/arogozhnikov/einops/blob/main/docs/2-einops-for-deep-learning.ipynb\">[2]</a>\n",
     "    <br />\n",
     "    <br />\n",
     "    </div>\n",
@@ -2452,7 +2452,7 @@
     "- [pytorch](http://github.com/pytorch/pytorch) and [einops](https://github.com/arogozhnikov/einops)\n",
     "- significant part of the code was taken from the official [examples](https://github.com/pytorch/examples) and [tutorials](https://github.com/pytorch/tutorials). All code fragments were taken for educational purpose.\n",
     "- (references for other code are given in source of this html)\n",
-    "- einops has a [tutorial](https://github.com/arogozhnikov/einops/tree/master/docs) for a more gentle introduction"
+    "- einops has a [tutorial](https://github.com/arogozhnikov/einops/tree/main/docs) for a more gentle introduction"
    ]
   },
   {


### PR DESCRIPTION
Minor fix of documentation links that became broken after `master` -> `main` migration.

GitHub does automatic redirects of the current `master` links, but nbviewer doesn't - displays 404 for all links from [`arogozhnikov/einops/blob/main/docs/README.md`](https://github.com/arogozhnikov/einops/blob/main/docs/README.md)
<img width="1185" alt="404" src="https://github.com/user-attachments/assets/cce59ae5-c179-4d0a-84d0-6dcec97c22f7">


PR consistently renames all leftover `master` mentions to `main`, so all links work as expected.