### PR TITLE
[Paddle] Update _backends.py to support pir.Value

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -623,7 +623,7 @@ class PaddleBackend(AbstractBackend):
         self.paddle = paddle
 
     def is_appropriate_type(self, tensor):
-        return isinstance(tensor, (self.paddle.Tensor, self.paddle.static.Variable))
+        return paddle.is_tensor(tensor)
 
     def from_numpy(self, x):
         tensor = self.paddle.to_tensor(x)

--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -623,7 +623,7 @@ class PaddleBackend(AbstractBackend):
         self.paddle = paddle
 
     def is_appropriate_type(self, tensor):
-        return paddle.is_tensor(tensor)
+        return self.paddle.is_tensor(tensor)
 
     def from_numpy(self, x):
         tensor = self.paddle.to_tensor(x)


### PR DESCRIPTION
Use paddle.is_tensor instead of isinstance to support `pir.Value` type when exporting model which use einops in computation
![image](https://github.com/user-attachments/assets/ab6c0c1b-5009-47b7-be98-bcfb79748c8e)

Related issue: <https://github.com/PaddlePaddle/PaddleScience/issues/1035>
