### PR TITLE
Add PyTensor backend

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,7 +13,11 @@ jobs:
         # cupy is not tested because it demands gpu
         # oneflow testing is dropped, see details at https://github.com/Oneflow-Inc/oneflow/issues/10340
         # paddle was switched off because of divergence with numpy in py3.10, paddle==2.6.1
-        frameworks: ['numpy pytorch tensorflow jax']
+        # The last pytensor release that supports python 3.8 doesn't include einsum, so we skip that combination.
+        frameworks: ['numpy pytorch tensorflow jax', 'pytensor']
+        exclude:
+          - python-version: '3.8'
+            frameworks: 'pytensor'
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Einops works with ...
 - [paddle](https://github.com/PaddlePaddle/Paddle) (community)
 - [oneflow](https://github.com/Oneflow-Inc/oneflow) (community)
 - [tinygrad](https://github.com/tinygrad/tinygrad) (community)
+- [pytensor](https://github.com/pymc-devs/pytensor) (community)
 
 Additionally, einops can be used with any framework that supports
 [Python array API standard](https://data-apis.org/array-api/latest/API_specification/index.html),

--- a/einops/tests/__init__.py
+++ b/einops/tests/__init__.py
@@ -87,7 +87,9 @@ def collect_test_backends(symbolic=False, layers=False) -> List[_backends.Abstra
             ]
     else:
         if not layers:
-            backend_types = []
+            backend_types = [
+                _backends.PyTensorBackend,
+            ]
         else:
             backend_types = [
                 _backends.TFKerasBackend,

--- a/einops/tests/run_tests.py
+++ b/einops/tests/run_tests.py
@@ -33,6 +33,7 @@ def main():
         # "paddle": ["paddlepaddle==0.0.0 -f https://www.paddlepaddle.org.cn/whl/linux/cpu-mkl/develop.html"],
         "paddle": ["paddlepaddle"],
         "oneflow": ["oneflow==0.9.0"],
+        "pytensor": ["pytensor"],
     }
 
     usage = f"""

--- a/einops/tests/test_einsum.py
+++ b/einops/tests/test_einsum.py
@@ -187,6 +187,7 @@ valid_backends_functional = [
     "cupy",
     "tensorflow.keras",
     "paddle",
+    "pytensor",
 ]
 
 
@@ -254,7 +255,7 @@ def test_functional_symbolic():
                 )
                 if predicted_out_data.shape != out_shape:
                     raise ValueError(f"Expected output shape {out_shape} but got {predicted_out_data.shape}")
-                assert np.testing.assert_array_almost_equal(predicted_out_data, expected_out_data, decimal=5)
+                np.testing.assert_array_almost_equal(predicted_out_data, expected_out_data, decimal=5)
 
 
 def test_functional_errors():

--- a/einops/tests/test_other.py
+++ b/einops/tests/test_other.py
@@ -210,7 +210,7 @@ def test_parse_shape_symbolic_ellipsis(backend):
     for static_shape, shape, pattern, expected in [
         ([10, 20], [None, None], "...", dict()),
         ([10], [None], "... a", dict(a=10)),
-        ([10, 20], [None], "... a", dict(a=20)),
+        ([10, 20], [None, None], "... a", dict(a=20)),
         ([10, 20, 30], [None, None, None], "... a", dict(a=30)),
         ([10, 20, 30, 40], [None, None, None, None], "... a", dict(a=40)),
         ([10], [None], "a ...", dict(a=10)),


### PR DESCRIPTION
Hi!

I understand that the library is moving away from specific backends in favor of the array api standard, but this was so much easier for us to implement and test.

From a first glance the array api standard compatibility suite seems completely oblivious to lazy backends right now. Will  double check and open an issue with them later if my suspicion is correct.

This also seems to test part of the test codebase that was untested since the drop of MxNet (?). Fixed two errors there.

Happy to remove PyTensor from the test suite if that's a drag / blocker. Not sure if we could test it from our CI as some of these test options are hardcoded in the library? Sounds like it should be easy to make them customizable though?

~~Currently all tests pass except the 3 tensor einsum multiplication. Issue opened in https://github.com/pymc-devs/pytensor/issues/1184~~ Should pass when it picks the new release 