### PR TITLE
Add mlx backend

### DIFF
--- a/einops/_backends.py
+++ b/einops/_backends.py
@@ -716,3 +716,46 @@ class PyTensorBackend(AbstractBackend):
 
     def einsum(self, pattern, *x):
         return self.pt.einsum(pattern, *x)
+
+
+class MLXBackend(AbstractBackend):
+    framework_name = "mlx"
+
+    def __init__(self):
+        import mlx.core as mx
+        import numpy as np
+
+        self.mx = mx
+        self.np = np
+
+    def is_appropriate_type(self, tensor):
+        return isinstance(tensor, self.mx.array)
+
+    def from_numpy(self, x):
+        return self.mx.array(x)
+
+    def to_numpy(self, x):
+        if x.dtype == self.mx.bfloat16:
+            x = x.astype(self.mx.float32)
+        return self.np.array(x)
+
+    def arange(self, start, stop):
+        return self.mx.arange(start, stop)
+
+    def stack_on_zeroth_dimension(self, tensors: list):
+        return self.mx.stack(tensors)
+
+    def add_axes(self, x, new_position):
+        return self.mx.expand_dims(x, new_position)
+
+    def tile(self, x, repeats):
+        return self.mx.tile(x, repeats)
+
+    def concat(self, tensors, axis: int):
+        return self.mx.concatenate(tensors, axis=axis)
+
+    def is_float_type(self, x):
+        return self.mx.issubdtype(x.dtype, self.mx.floating)
+
+    def einsum(self, pattern, *x):
+        return self.mx.einsum(pattern, *x)

--- a/einops/tests/run_tests.py
+++ b/einops/tests/run_tests.py
@@ -34,6 +34,7 @@ def main():
         "paddle": ["paddlepaddle"],
         "oneflow": ["oneflow==0.9.0"],
         "pytensor": ["pytensor"],
+        "mlx": ["mlx"],
     }
 
     usage = f"""

--- a/einops/tests/test_einsum.py
+++ b/einops/tests/test_einsum.py
@@ -191,6 +191,7 @@ valid_backends_functional = [
     "tensorflow.keras",
     "paddle",
     "pytensor",
+    "mlx",
 ]
 
 


### PR DESCRIPTION
This resolves the issue in https://github.com/arogozhnikov/einops/issues/295#issuecomment-2850339745, adding a backend for MLX so that we can use `einsum`. Since MLX has very similar APIs to PyTorch and Numpy, the `MLXBackend` looks very similar to `NumpyBackend` and `TorchBackend`.

The tests passed on my Mac.

```
$ uv run einops/tests/run_tests.py mlx
running: ['python', '-m', 'pytest', '.']
=========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /Users/zhiqiu/offline_code/opensource/einops
configfile: pyproject.toml
collected 64 items                                                                                                                        

test_einsum.py ....                                                                                                                 [  6%]
test_examples.py .s                                                                                                                 [  9%]
test_layers.py ....ssss..                                                                                                           [ 25%]
test_ops.py ......................s.                                                                                                [ 62%]
test_other.py ............ss.s                                                                                                      [ 87%]
test_packing.py ....                                                                                                                [ 93%]
test_parsing.py ....                                                                                                                [100%]

============================================================ warnings summary =============================================================
einops/tests/test_layers.py::test_einmix_decomposition
  /Users/zhiqiu/offline_code/opensource/einops/einops/layers/_einmix.py:63: UserWarning: EinMix: weight has no dimensions (means multiplication by a number)
    self.initialize_einmix(

einops/tests/test_other.py::testmod
  /Users/zhiqiu/offline_code/opensource/einops/.venv/lib/python3.12/site-packages/_pytest/python.py:163: PytestReturnNotNoneWarning: Expected None, but einops/tests/test_other.py::testmod returned TestResults(failed=0, attempted=0), which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================ 55 passed, 9 skipped, 2 warnings in 0.18s ================================================
```