### PR TITLE
add MindSpore backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Einops works with ...
 - [oneflow](https://github.com/Oneflow-Inc/oneflow) (community)
 - [tinygrad](https://github.com/tinygrad/tinygrad) (community)
 - [pytensor](https://github.com/pymc-devs/pytensor) (community)
+- [MindSpore](https://www.mindspore.cn/en) (community)
 
 Additionally, einops can be used with any framework that supports
 [Python array API standard](https://data-apis.org/array-api/latest/API_specification/index.html),

--- a/einops/layers/mindspore.py
+++ b/einops/layers/mindspore.py
@@ -1,0 +1,52 @@
+from typing import Dict, Optional, cast
+
+from mindspore import Parameter, mint, nn
+from mindspore.common.initializer import Uniform, initializer
+
+from . import RearrangeMixin, ReduceMixin
+from ._einmix import _EinmixMixin
+
+__author__ = "Rustam Khadipash"
+
+
+class Rearrange(RearrangeMixin, nn.Cell):
+    def construct(self, input):
+        return self._apply_recipe(input)
+
+
+class Reduce(ReduceMixin, nn.Cell):
+    def construct(self, input):
+        return self._apply_recipe(input)
+
+
+class EinMix(_EinmixMixin, nn.Cell):
+    def _create_parameters(self, weight_shape, weight_bound, bias_shape, bias_bound):
+        self.weight = Parameter(initializer(Uniform(weight_bound), weight_shape))
+        self.bias = None
+        if bias_shape is not None:
+            self.bias = Parameter(initializer(Uniform(bias_bound), bias_shape))
+
+    def _create_rearrange_layers(
+        self,
+        pre_reshape_pattern: Optional[str],
+        pre_reshape_lengths: Optional[Dict],
+        post_reshape_pattern: Optional[str],
+        post_reshape_lengths: Optional[Dict],
+    ):
+        self.pre_rearrange = None
+        if pre_reshape_pattern is not None:
+            self.pre_rearrange = Rearrange(pre_reshape_pattern, **cast(dict, pre_reshape_lengths))
+
+        self.post_rearrange = None
+        if post_reshape_pattern is not None:
+            self.post_rearrange = Rearrange(post_reshape_pattern, **cast(dict, post_reshape_lengths))
+
+    def construct(self, input):
+        if self.pre_rearrange is not None:
+            input = self.pre_rearrange(input)
+        result = mint.einsum(self.einsum_pattern, input, self.weight)
+        if self.bias is not None:
+            result += self.bias
+        if self.post_rearrange is not None:
+            result = self.post_rearrange(result)
+        return result

--- a/einops/tests/__init__.py
+++ b/einops/tests/__init__.py
@@ -78,12 +78,14 @@ def collect_test_backends(symbolic=False, layers=False) -> List[_backends.Abstra
                 _backends.OneFlowBackend,
                 _backends.PaddleBackend,
                 _backends.CupyBackend,
+                _backends.MindSporeBackend,
             ]
         else:
             backend_types = [
                 _backends.TorchBackend,
                 _backends.OneFlowBackend,
                 _backends.PaddleBackend,
+                _backends.MindSporeBackend,
             ]
     else:
         if not layers:

--- a/einops/tests/run_tests.py
+++ b/einops/tests/run_tests.py
@@ -34,6 +34,7 @@ def main():
         "paddle": ["paddlepaddle"],
         "oneflow": ["oneflow==0.9.0"],
         "pytensor": ["pytensor"],
+        "mindspore": ["mindspore>=2.6.0"],
     }
 
     usage = f"""

--- a/einops/tests/test_einsum.py
+++ b/einops/tests/test_einsum.py
@@ -169,7 +169,7 @@ test_functional_cases = [
 def test_layer():
     for backend in collect_test_backends(layers=True, symbolic=False):
         rng = np.random.default_rng()
-        if backend.framework_name in ["tensorflow", "torch", "oneflow", "paddle"]:
+        if backend.framework_name in ["tensorflow", "torch", "oneflow", "paddle", "mindspore"]:
             layer_type = backend.layers().EinMix
             for args, in_shape, out_shape in test_layer_cases:
                 layer = args(layer_type)
@@ -191,6 +191,7 @@ valid_backends_functional = [
     "tensorflow.keras",
     "paddle",
     "pytensor",
+    "mindspore",
 ]
 
 

--- a/einops/tests/test_examples.py
+++ b/einops/tests/test_examples.py
@@ -143,7 +143,7 @@ def test_rearrange_examples():
             # now with strides
             x = np.arange(10 * 2 * 20 * 3 * 30 * 1 * 40).reshape([10 * 2, 20 * 3, 30 * 1, 40 * 1])
             # known torch bug - torch doesn't support negative steps
-            last_step = -1 if (backend.framework_name != "torch" and backend.framework_name != "oneflow") else 1
+            last_step = -1 if backend.framework_name not in ("torch", "oneflow", "mindspore") else 1
             indexing_expression = np.index_exp[::2, ::3, ::1, ::last_step]
             result1 = test(x[indexing_expression])
             result2 = backend.to_numpy(test(backend.from_numpy(x)[indexing_expression]))

--- a/einops/tests/test_ops.py
+++ b/einops/tests/test_ops.py
@@ -312,7 +312,9 @@ def test_reduction_stress_imperatives():
             max_dim = 11
             if "oneflow" in backend.framework_name:
                 max_dim = 7
-            if "paddle" in backend.framework_name:
+            elif "mindspore" in backend.framework_name:
+                max_dim = 8
+            elif "paddle" in backend.framework_name:
                 max_dim = 9
             for n_axes in range(max_dim):
                 shape = rng.integers(2, 4, size=n_axes)


### PR DESCRIPTION
This PR adds support for the MindSpore framework (**Ascend NPU only**), including backend implementation, layer support, and test integration. The changes ensure that `einops` operations and layers work seamlessly with MindSpore tensors, and that all relevant tests include MindSpore as a backend.

```shell
>>> python -m einops.tests.run_tests mindspore
...
================= 51 passed, 13 skipped, 35 warnings in 28.24s =================
```