### PR TITLE
Skip `allow_in_graph` if torch >= 2.8

### DIFF
--- a/einops/_torch_specific.py
+++ b/einops/_torch_specific.py
@@ -104,6 +104,11 @@ def allow_ops_in_compiled_graph():
     if hasattr(torch, "__version__") and torch.__version__[0] < "2":
         # torch._dynamo and torch.compile appear in pytorch 2.0
         return
+
+    if hasattr(torch, "__version__") and torch.__version__ >= "2.8":
+        # einops don't need to use allow_in graph for torch 2.8 and above
+        return
+
     try:
         from torch._dynamo import allow_in_graph
     except ImportError:


### PR DESCRIPTION
Starting from PyTorch 2.8, einops no longer needs to rely on `allow_in_graph` for its own ops. PyTorch follows the same approach internally, and I’d like to remove this usage from the PyTorch codebase as well. Dynamo can trace through the einops codebase, and we have tests in place to catch any regressions early.

https://github.com/pytorch/pytorch/blob/4771394d4883e3f4d94a778298a3449b2e1d4a80/torch/_dynamo/decorators.py#L826-L847

I believe that removing `allow_in_graph` from both libraries is a better approach than what I implemented in https://github.com/pytorch/pytorch/pull/155310. My idea is to start with einops first and remove the same from PyTorch when einops releases a new version.

cc @williamwen42 @zou3519