### PR TITLE
require that `.einops.Tensor` types implement `__array_namespace__()`

### DIFF
--- a/einops/einops.py
+++ b/einops/einops.py
@@ -3,6 +3,7 @@ import itertools
 import string
 import typing
 from collections import OrderedDict
+from types import ModuleType
 from typing import Any, Optional, Protocol, TypeVar, Union, cast, overload
 
 if typing.TYPE_CHECKING:
@@ -13,7 +14,12 @@ from . import EinopsError
 from ._backends import get_backend
 from .parsing import AnonymousAxis, ParsedExpression, _ellipsis
 
-Tensor = TypeVar("Tensor")
+
+class _SupportsArrayNamespace(Protocol):
+    def __array_namespace__(self, /) -> ModuleType: ...
+
+
+Tensor = TypeVar("Tensor", bound=_SupportsArrayNamespace)
 
 
 class ReductionCallable(Protocol):


### PR DESCRIPTION
This narrows the `einops.einops.Tensor` type variable so that it no longer accepts any type, and instead requires the type to (at least) the `__array_namespace__` method, i.e. the bare minimum for something to be considered an array-api object  ([docs](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__array_namespace__.html)).

Note that the `__array_namespace__` method does not include an `api_version` kwarg. But this is no problem, because Barara Liskov's substitution principle ensures that types that implement `__array_namespace__` **with** the `api_version` kwarg will also be assignable here. The reason I did not include the `api_version` kwarg is for compatibility with older array api versions.