### PR TITLE
also accept `list[Tensor]` in `.array_api.reduce`

### DIFF
--- a/einops/array_api.py
+++ b/einops/array_api.py
@@ -32,11 +32,11 @@ def reduce(tensor: list[Tensor] | Tensor, pattern: str, reduction: Reduction, **
         raise EinopsError(message + f"\n {e}") from None
 
 
-def repeat(tensor: Tensor, pattern: str, **axes_lengths) -> Tensor:
+def repeat(tensor: list[Tensor] | Tensor, pattern: str, **axes_lengths) -> Tensor:
     return reduce(tensor, pattern, reduction="repeat", **axes_lengths)
 
 
-def rearrange(tensor: Tensor, pattern: str, **axes_lengths) -> Tensor:
+def rearrange(tensor: list[Tensor] | Tensor, pattern: str, **axes_lengths) -> Tensor:
     return reduce(tensor, pattern, reduction="rearrange", **axes_lengths)
 
 

--- a/einops/array_api.py
+++ b/einops/array_api.py
@@ -4,7 +4,7 @@ from .einops import EinopsError, Reduction, Tensor, _apply_recipe_array_api, _pr
 from .packing import analyze_pattern, prod
 
 
-def reduce(tensor: Tensor, pattern: str, reduction: Reduction, **axes_lengths: int) -> Tensor:
+def reduce(tensor: list[Tensor] | Tensor, pattern: str, reduction: Reduction, **axes_lengths: int) -> Tensor:
     if isinstance(tensor, list):
         if len(tensor) == 0:
             raise TypeError("Einops can't be applied to an empty list")


### PR DESCRIPTION
Currently, passing e.g. `list[np.ndarray]` to `reduce` will cause type-checkers to infer the return type as `list[np.ndarray]`. Clearly, that's not right, and it should have `np.ndarray` as return type. 
This, together with #408, ensures that this will be the case.