### PR TITLE
modernize annotations with PEP 604 union syntax

### DIFF
--- a/einops/einops.py
+++ b/einops/einops.py
@@ -3,7 +3,7 @@ import itertools
 import string
 import typing
 from collections import OrderedDict
-from typing import Any, Optional, Protocol, TypeVar, Union, cast, overload
+from typing import Any, Protocol, TypeVar, cast, overload
 
 if typing.TYPE_CHECKING:
     # for docstrings in pycharm
@@ -20,7 +20,7 @@ class ReductionCallable(Protocol):
     def __call__(self, tensor: Tensor, axes: tuple[int, ...], /) -> Tensor: ...
 
 
-Reduction = Union[str, ReductionCallable]
+Reduction = str | ReductionCallable
 Size = typing.Any
 
 _reductions = ("min", "max", "sum", "mean", "prod", "any", "all")
@@ -107,7 +107,7 @@ def _optimize_transformation(init_shapes, reduced_axes, axes_reordering, final_s
     return init_shapes, reduced_axes, axes_reordering, final_shapes
 
 
-CookedRecipe = tuple[Optional[list[int]], Optional[list[int]], list[int], dict[int, int], Optional[list[int]], int]
+CookedRecipe = tuple[list[int] | None, list[int] | None, list[int], dict[int, int], list[int] | None, int]
 
 # Actual type is tuple[tuple[str, int], ...]
 # However torch.jit.script does not "understand" the correct type,
@@ -202,7 +202,7 @@ def _reconstruct_from_shape_uncached(
     # at this point all axes_lengths are computed (either have values or variables, but not Nones)
 
     # elementary axes are ordered as they appear in input, then all added axes
-    init_shapes: Optional[list[int]] = axes_lengths[: len(self.axes_permutation)] if need_init_reshape else None
+    init_shapes: list[int] | None = axes_lengths[: len(self.axes_permutation)] if need_init_reshape else None
 
     need_final_reshape = False
     final_shapes: list[int] = []
@@ -221,7 +221,7 @@ def _reconstruct_from_shape_uncached(
 
     n_axes_after_adding_axes = len(added_axes) + len(self.axes_permutation)
 
-    axes_reordering: Optional[list[int]] = self.axes_permutation
+    axes_reordering: list[int] | None = self.axes_permutation
     if self.axes_permutation == list(range(len(self.axes_permutation))):
         axes_reordering = None
 
@@ -373,7 +373,7 @@ def _prepare_transformation_recipe(
         rght_composition = rght.composition
 
     # parsing all dimensions to find out lengths
-    axis_name2known_length: dict[Union[str, AnonymousAxis], int] = OrderedDict()
+    axis_name2known_length: OrderedDict[str | AnonymousAxis, int] = OrderedDict()
     for composite_axis in left_composition:
         for axis_name in composite_axis:
             if isinstance(axis_name, AnonymousAxis):
@@ -470,7 +470,7 @@ def reduce(tensor: list[Tensor], pattern: str, reduction: Reduction, **axes_leng
 def reduce(tensor: Tensor, pattern: str, reduction: Reduction, **axes_lengths: Size) -> Tensor: ...
 
 
-def reduce(tensor: Union[Tensor, list[Tensor]], pattern: str, reduction: Reduction, **axes_lengths: Size) -> Tensor:
+def reduce(tensor: Tensor | list[Tensor], pattern: str, reduction: Reduction, **axes_lengths: Size) -> Tensor:
     """
     einops.reduce combines rearrangement and reduction using reader-friendly notation.
 
@@ -563,7 +563,7 @@ def rearrange(tensor: list[Tensor], pattern: str, **axes_lengths: Size) -> Tenso
 def rearrange(tensor: Tensor, pattern: str, **axes_lengths: Size) -> Tensor: ...
 
 
-def rearrange(tensor: Union[Tensor, list[Tensor]], pattern: str, **axes_lengths: Size) -> Tensor:
+def rearrange(tensor: Tensor | list[Tensor], pattern: str, **axes_lengths: Size) -> Tensor:
     """
     einops.rearrange is a reader-friendly smart element reordering for multidimensional tensors.
     This operation includes functionality of transpose (axes permutation), reshape (view), squeeze, unsqueeze,
@@ -629,7 +629,7 @@ def repeat(tensor: list[Tensor], pattern: str, **axes_lengths: Size) -> Tensor: 
 def repeat(tensor: Tensor, pattern: str, **axes_lengths: Size) -> Tensor: ...
 
 
-def repeat(tensor: Union[Tensor, list[Tensor]], pattern: str, **axes_lengths: Size) -> Tensor:
+def repeat(tensor: Tensor | list[Tensor], pattern: str, **axes_lengths: Size) -> Tensor:
     """
     einops.repeat allows reordering elements and repeating them in arbitrary combinations.
     This operation includes functionality of repeat, tile, and broadcast functions.
@@ -867,7 +867,7 @@ def einsum(tensor1: Tensor, tensor2: Tensor, tensor3: Tensor, pattern: str, /) -
 def einsum(tensor1: Tensor, tensor2: Tensor, tensor3: Tensor, tensor4: Tensor, pattern: str, /) -> Tensor: ...
 
 
-def einsum(*tensors_and_pattern: Union[Tensor, str]) -> Tensor:
+def einsum(*tensors_and_pattern: Tensor | str) -> Tensor:
     r"""
     einops.einsum calls einsum operations with einops-style named
     axes indexing, computing tensor products with an arbitrary

--- a/einops/layers/_einmix.py
+++ b/einops/layers/_einmix.py
@@ -1,6 +1,6 @@
 import string
 import warnings
-from typing import Any, Optional
+from typing import Any
 
 from einops import EinopsError
 from einops.einops import _product
@@ -13,7 +13,7 @@ def _report_axes(axes: set, report_message: str):
 
 
 class _EinmixMixin:
-    def __init__(self, pattern: str, weight_shape: str, bias_shape: Optional[str] = None, **axes_lengths: Any):
+    def __init__(self, pattern: str, weight_shape: str, bias_shape: str | None = None, **axes_lengths: Any):
         """
         EinMix - Einstein summation with automated tensor management and axis packing/unpacking.
 
@@ -64,7 +64,7 @@ class _EinmixMixin:
             pattern=pattern, weight_shape=weight_shape, bias_shape=bias_shape, axes_lengths=axes_lengths
         )
 
-    def initialize_einmix(self, pattern: str, weight_shape: str, bias_shape: Optional[str], axes_lengths: dict):
+    def initialize_einmix(self, pattern: str, weight_shape: str, bias_shape: str | None, axes_lengths: dict):
         left_pattern, right_pattern = pattern.split("->")
         left = ParsedExpression(left_pattern)
         right = ParsedExpression(right_pattern)
@@ -186,10 +186,10 @@ class _EinmixMixin:
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         raise NotImplementedError("Should be defined in framework implementations")
 
@@ -212,10 +212,10 @@ class _EinmixDebugger(_EinmixMixin):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_reshape_pattern = pre_reshape_pattern
         self.pre_reshape_lengths = pre_reshape_lengths

--- a/einops/layers/flax.py
+++ b/einops/layers/flax.py
@@ -1,5 +1,5 @@
 from dataclasses import field
-from typing import Optional, cast
+from typing import cast
 
 import flax.linen as nn
 import jax
@@ -37,7 +37,7 @@ class Rearrange(nn.Module):
 class EinMix(nn.Module, _EinmixMixin):
     pattern: str
     weight_shape: str
-    bias_shape: Optional[str] = None
+    bias_shape: str | None = None
     sizes: dict = field(default_factory=dict)
 
     def setup(self):
@@ -58,10 +58,10 @@ class EinMix(nn.Module, _EinmixMixin):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_rearrange = None
         if pre_reshape_pattern is not None:

--- a/einops/layers/oneflow.py
+++ b/einops/layers/oneflow.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 import oneflow as flow
 
@@ -30,10 +30,10 @@ class EinMix(_EinmixMixin, flow.nn.Module):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_rearrange = None
         if pre_reshape_pattern is not None:

--- a/einops/layers/paddle.py
+++ b/einops/layers/paddle.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 import paddle
 
@@ -33,10 +33,10 @@ class EinMix(_EinmixMixin, paddle.nn.Layer):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_rearrange = None
         if pre_reshape_pattern is not None:

--- a/einops/layers/tensorflow.py
+++ b/einops/layers/tensorflow.py
@@ -11,7 +11,7 @@ Layers in einops==0.8.0 were re-implemented
 
 """
 
-from typing import Optional, cast
+from typing import cast
 
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
@@ -52,10 +52,10 @@ class EinMix(_EinmixMixin, Layer):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_rearrange = None
         if pre_reshape_pattern is not None:

--- a/einops/layers/torch.py
+++ b/einops/layers/torch.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import cast
 
 import torch
 
@@ -44,10 +44,10 @@ class EinMix(_EinmixMixin, torch.nn.Module):
 
     def _create_rearrange_layers(
         self,
-        pre_reshape_pattern: Optional[str],
-        pre_reshape_lengths: Optional[dict],
-        post_reshape_pattern: Optional[str],
-        post_reshape_lengths: Optional[dict],
+        pre_reshape_pattern: str | None,
+        pre_reshape_lengths: dict | None,
+        post_reshape_pattern: str | None,
+        post_reshape_lengths: dict | None,
     ):
         self.pre_rearrange = None
         if pre_reshape_pattern is not None:

--- a/einops/packing.py
+++ b/einops/packing.py
@@ -1,14 +1,12 @@
 from collections.abc import Sequence
 from functools import lru_cache
-from typing import TypeVar, Union
 
 from einops import EinopsError
 from einops._backends import get_backend
+from einops.einops import Tensor
 from einops.parsing import ParsedExpression
 
-Tensor = TypeVar("Tensor")
-
-Shape = Union[tuple[int, ...], list[int]]
+Shape = tuple[int, ...] | list[int]
 
 
 @lru_cache(maxsize=128)

--- a/einops/parsing.py
+++ b/einops/parsing.py
@@ -1,6 +1,5 @@
 import keyword
 import warnings
-from typing import Optional, Union
 
 from einops import EinopsError
 
@@ -30,12 +29,12 @@ class ParsedExpression:
 
     def __init__(self, expression: str, *, allow_underscore: bool = False, allow_duplicates: bool = False):
         self.has_ellipsis: bool = False
-        self.has_ellipsis_parenthesized: Optional[bool] = None
+        self.has_ellipsis_parenthesized: bool | None = None
         self.identifiers: set[str] = set()
         # that's axes like 2, 3, 4 or 5. Axes with size 1 are exceptional and replaced with empty composition
         self.has_non_unitary_anonymous_axes: bool = False
         # composition keeps structure of composite axes, see how different corner cases are handled in tests
-        self.composition: list[Union[list[str], str]] = []
+        self.composition: list[list[str] | str] = []
         if "." in expression:
             if "..." not in expression:
                 raise EinopsError("Expression may contain dots only inside ellipsis (...)")
@@ -46,7 +45,7 @@ class ParsedExpression:
             expression = expression.replace("...", _ellipsis)
             self.has_ellipsis = True
 
-        bracket_group: Optional[list[str]] = None
+        bracket_group: list[str] | None = None
 
         def add_axis_name(x):
             if x in self.identifiers:


### PR DESCRIPTION
This replaces the legacy `typing.Union` and `typing.Optional` special forms with fancy [PEP 604](https://peps.python.org/pep-0604/) union syntax. It's functionally equivalent, and type-checkers don't care. So it's mostly beneficial for readability. Having fewer `typing` imports also helps.

Oh and with #408 in mind, I also took the liberty of de-duplicating the `Tensor` type variable declaration in `einops.packing`. It's admittedly a bit out of place here, but I liked that I was able to remove all typing imports this way. But if you think it's (too) out of scope, I'd understand, and wouldn't mind reverting that bit. 