### PR TITLE
explicitly mark type aliases as `TypeAlias` (PEP 613)

### DIFF
--- a/einops/array_api.py
+++ b/einops/array_api.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from typing import TypeAlias
 
 from .einops import EinopsError, Reduction, Tensor, _apply_recipe_array_api, _prepare_transformation_recipe
 from .packing import analyze_pattern, prod
@@ -46,7 +47,7 @@ def asnumpy(tensor: Tensor):
     return np.from_dlpack(tensor)
 
 
-Shape = tuple
+Shape: TypeAlias = tuple
 
 
 def pack(tensors: Sequence[Tensor], pattern: str) -> tuple[Tensor, list[Shape]]:

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -3,7 +3,7 @@ import itertools
 import string
 import typing
 from collections import OrderedDict
-from typing import Any, Optional, Protocol, TypeVar, Union, cast, overload
+from typing import Any, Optional, Protocol, TypeAlias, TypeVar, Union, cast, overload
 
 if typing.TYPE_CHECKING:
     # for docstrings in pycharm
@@ -20,8 +20,8 @@ class ReductionCallable(Protocol):
     def __call__(self, tensor: Tensor, axes: tuple[int, ...], /) -> Tensor: ...
 
 
-Reduction = Union[str, ReductionCallable]
-Size = typing.Any
+Reduction: TypeAlias = Union[str, ReductionCallable]
+Size: TypeAlias = typing.Any
 
 _reductions = ("min", "max", "sum", "mean", "prod", "any", "all")
 
@@ -107,13 +107,15 @@ def _optimize_transformation(init_shapes, reduced_axes, axes_reordering, final_s
     return init_shapes, reduced_axes, axes_reordering, final_shapes
 
 
-CookedRecipe = tuple[Optional[list[int]], Optional[list[int]], list[int], dict[int, int], Optional[list[int]], int]
+CookedRecipe: TypeAlias = tuple[
+    Optional[list[int]], Optional[list[int]], list[int], dict[int, int], Optional[list[int]], int
+]
 
 # Actual type is tuple[tuple[str, int], ...]
 # However torch.jit.script does not "understand" the correct type,
 # and torch_specific will use list version.
-HashableAxesLengths = tuple[tuple[str, int], ...]
-FakeHashableAxesLengths = list[tuple[str, int]]
+HashableAxesLengths: TypeAlias = tuple[tuple[str, int], ...]
+FakeHashableAxesLengths: TypeAlias = list[tuple[str, int]]
 
 
 class TransformRecipe:

--- a/einops/packing.py
+++ b/einops/packing.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from functools import lru_cache
-from typing import TypeVar, Union
+from typing import TypeAlias, TypeVar, Union
 
 from einops import EinopsError
 from einops._backends import get_backend
@@ -8,7 +8,7 @@ from einops.parsing import ParsedExpression
 
 Tensor = TypeVar("Tensor")
 
-Shape = Union[tuple[int, ...], list[int]]
+Shape: TypeAlias = Union[tuple[int, ...], list[int]]
 
 
 @lru_cache(maxsize=128)

--- a/einops/tests/test_layers.py
+++ b/einops/tests/test_layers.py
@@ -341,12 +341,8 @@ def test_flax_layers():
         value0 = eval_at_point(params)
         value1, grad1 = vandg(params)
         assert jnp.allclose(value0, value1)
-        if jax.__version__ < "0.6.0":
-            tree_map = jax.tree_map
-        else:
-            tree_map = jax.tree.map
 
-        params2 = tree_map(lambda x1, x2: x1 - x2 * 0.001, params, grad1)
+        params2 = jax.tree.map(lambda x1, x2: x1 - x2 * 0.001, params, grad1)
 
         value2 = eval_at_point(params2)
         assert value0 >= value2, (value0, value2)


### PR DESCRIPTION
The motivation for this is explained in detail in [PEP 613](https://peps.python.org/pep-0613/) and in the [Python typing spec](https://typing.python.org/en/latest/spec/aliases.html#type-aliases). 
The `typing.TypeAlias` special form is available since Python 3.10, which matches the minimum required Python version of `einops`.