### PR TITLE
Import _torch_specific when torch is available

### DIFF
--- a/einops/__init__.py
+++ b/einops/__init__.py
@@ -15,3 +15,9 @@ __all__ = ["EinopsError", "asnumpy", "einsum", "pack", "parse_shape", "rearrange
 
 from .einops import asnumpy, einsum, parse_shape, rearrange, reduce, repeat
 from .packing import pack, unpack
+
+try:
+    import torch  # noqa: F401
+    from einops import _torch_specific  # noqa: F401
+except ImportError:
+    pass


### PR DESCRIPTION
## Summary

When users do `import einops`, the `_torch_specific` module was never imported, so `allow_ops_in_compiled_graph()` was never called. This causes `torch.compile` to fail with torch 2.7+ due to unregistered operations.

## Problem

Starting with [this pytorch commit](https://github.com/pytorch/pytorch/commit/270ad513c8a4aac9f1ee6c84986f7157547b6e28), torch 2.7 no longer auto-imports `einops._torch_specific`. This means `allow_in_graph()` is never called for einops operations, leading to:

```
torch._dynamo.exc.Unsupported: Unsupported method call
  Explanation: Dynamo does not know how to trace method `symmetric_difference` of class `type`
```

## Fix

Add a lazy import of `_torch_specific` in `__init__.py` when torch is available. This ensures the ops are registered in the dynamo graph when torch is installed, while keeping torch as an optional dependency.

Fixes #377