### PR TITLE
fix mypy errors in `einops.parsing` and add missing annotations

### DIFF
--- a/einops/parsing.py
+++ b/einops/parsing.py
@@ -1,5 +1,6 @@
 import keyword
 import warnings
+from collections.abc import Sequence
 
 from einops import EinopsError
 
@@ -8,6 +9,8 @@ _ellipsis: str = "…"  # NB, this is a single unicode symbol. String is used as
 
 class AnonymousAxis:
     """Important thing: all instances of this class are not equal to each other"""
+
+    value: int
 
     def __init__(self, value: str):
         self.value = int(value)
@@ -30,11 +33,11 @@ class ParsedExpression:
     def __init__(self, expression: str, *, allow_underscore: bool = False, allow_duplicates: bool = False):
         self.has_ellipsis: bool = False
         self.has_ellipsis_parenthesized: bool | None = None
-        self.identifiers: set[str] = set()
+        self.identifiers: set[str | AnonymousAxis] = set()
         # that's axes like 2, 3, 4 or 5. Axes with size 1 are exceptional and replaced with empty composition
         self.has_non_unitary_anonymous_axes: bool = False
         # composition keeps structure of composite axes, see how different corner cases are handled in tests
-        self.composition: list[list[str] | str] = []
+        self.composition: list[Sequence[str | AnonymousAxis] | str] = []
         if "." in expression:
             if "..." not in expression:
                 raise EinopsError("Expression may contain dots only inside ellipsis (...)")
@@ -45,9 +48,9 @@ class ParsedExpression:
             expression = expression.replace("...", _ellipsis)
             self.has_ellipsis = True
 
-        bracket_group: list[str] | None = None
+        bracket_group: list[str | AnonymousAxis] | None = None
 
-        def add_axis_name(x):
+        def add_axis_name(x: str) -> None:
             if x in self.identifiers:
                 if not (allow_underscore and x == "_") and not allow_duplicates:
                     raise EinopsError(f'Indexing expression contains duplicate dimension "{x}"')
@@ -109,8 +112,8 @@ class ParsedExpression:
         if current_identifier is not None:
             add_axis_name(current_identifier)
 
-    def flat_axes_order(self) -> list:
-        result = []
+    def flat_axes_order(self) -> list[str]:
+        result: list[str] = []
         for composed_axis in self.composition:
             assert isinstance(composed_axis, list), "does not work with ellipsis"
             for axis in composed_axis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ select = [
     "PIE",    # flake8-pie
     "ISC",    # implicit string concatenation
     "PTH",    # pathlib
-    "N818",   # error class name ends with error 
+    "N818",   # error class name ends with error
     "UP",     # pyupgrade
     "C4",     # comprehensions
     "N804",   # cls
@@ -114,9 +114,9 @@ select = [
     "PL",     # all pylint rules (error, conventions, warnigns)
     "FLY",    # static joins -> f-string
     "NPY201", # numpy 2 deprecations
-    "RET501",  
-    "RET502", 
-    "RET503", 
+    "RET501",
+    "RET502",
+    "RET503",
 ]
 # this notebook is not really a notebook,
 # but a set of examples to be compared
@@ -145,6 +145,8 @@ exclude = ["*Pytorch.ipynb"]
 # mypy can't tolerate two 'utils' module, so we exclude one
 exclude = "./docs/utils/"
 check_untyped_defs = true
+local_partial_types = true
+allow_redefinition_new = true
 
 [[tool.mypy.overrides]]
 module = [


### PR DESCRIPTION
I also enabled some new mypy config oiptions that'll be enabled by default in mypy 2.0, and are needed to avoid several `no-redef` false positive mypy errors in `parsing.py`.