### PR TITLE
fix mypy errors in `einops.layers.torch` and add missing annotations

### DIFF
--- a/einops/layers/torch.py
+++ b/einops/layers/torch.py
@@ -11,30 +11,34 @@ __author__ = "Alex Rogozhnikov"
 
 
 class Rearrange(RearrangeMixin, torch.nn.Module):
-    def forward(self, input):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
         recipe = self._multirecipe[input.ndim]
-        return apply_for_scriptable_torch(recipe, input, reduction_type="rearrange", axes_dims=self._axes_lengths)
+        return apply_for_scriptable_torch(recipe, input, reduction_type="rearrange", axes_dims=self._axes_lengths)  # type: ignore[arg-type]
 
     def _apply_recipe(self, x):
-        # overriding parent method to prevent it's scripting
+        # overriding parent method to prevent its scripting
         pass
 
 
 class Reduce(ReduceMixin, torch.nn.Module):
-    def forward(self, input):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
         recipe = self._multirecipe[input.ndim]
-        return apply_for_scriptable_torch(recipe, input, reduction_type=self.reduction, axes_dims=self._axes_lengths)
+        return apply_for_scriptable_torch(recipe, input, reduction_type=self.reduction, axes_dims=self._axes_lengths)  # type: ignore[arg-type]
 
     def _apply_recipe(self, x):
-        # overriding parent method to prevent it's scripting
+        # overriding parent method to prevent its scripting
         pass
 
 
 class EinMix(_EinmixMixin, torch.nn.Module):
-    def _create_parameters(self, weight_shape, weight_bound, bias_shape, bias_bound):
+    def _create_parameters(
+        self, weight_shape: list[int], weight_bound: float, bias_shape: list[int] | None, bias_bound: float
+    ) -> None:
         self.weight = torch.nn.Parameter(
             torch.zeros(weight_shape).uniform_(-weight_bound, weight_bound), requires_grad=True
         )
+
+        self.bias: torch.nn.Parameter | None
         if bias_shape is not None:
             self.bias = torch.nn.Parameter(
                 torch.zeros(bias_shape).uniform_(-bias_bound, bias_bound), requires_grad=True
@@ -45,19 +49,19 @@ class EinMix(_EinmixMixin, torch.nn.Module):
     def _create_rearrange_layers(
         self,
         pre_reshape_pattern: str | None,
-        pre_reshape_lengths: dict | None,
+        pre_reshape_lengths: dict[str, int] | None,
         post_reshape_pattern: str | None,
-        post_reshape_lengths: dict | None,
-    ):
-        self.pre_rearrange = None
+        post_reshape_lengths: dict[str, int] | None,
+    ) -> None:
+        self.pre_rearrange: Rearrange | None = None
         if pre_reshape_pattern is not None:
-            self.pre_rearrange = Rearrange(pre_reshape_pattern, **cast(dict, pre_reshape_lengths))
+            self.pre_rearrange = Rearrange(pre_reshape_pattern, **cast(dict[str, int], pre_reshape_lengths))
 
-        self.post_rearrange = None
+        self.post_rearrange: Rearrange | None = None
         if post_reshape_pattern is not None:
-            self.post_rearrange = Rearrange(post_reshape_pattern, **cast(dict, post_reshape_lengths))
+            self.post_rearrange = Rearrange(post_reshape_pattern, **cast(dict[str, int], post_reshape_lengths))
 
-    def forward(self, input):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
         if self.pre_rearrange is not None:
             input = self.pre_rearrange(input)
         result = torch.einsum(self.einsum_pattern, input, self.weight)


### PR DESCRIPTION
Here's the last PR in the type-coverage series, increasing the type coverage by 3.61%, which, together with the my other PRs from today, should bring einops' coverage to 100% :tada:.

This also fixes the mypy errors in `einops.layers.torch`. I was forced to `# type: ignore` some of them, because otherwise the tests would fail because of limitations in the pytorch JIT runtime type-checker (it doesn't understand `tuple[int, ...]` or `collections.abc.Sequence`, for example).

Note that there are still some mypy errors left, most of them in private modules.