### PR TITLE
fix: handle empty list in pack() and fix typo in error message

### DIFF
--- a/einops/packing.py
+++ b/einops/packing.py
@@ -68,7 +68,9 @@ def pack(tensors: Sequence[Tensor], pattern: str) -> tuple[Tensor, list[Shape]]:
     """
     n_axes_before, n_axes_after, min_axes = analyze_pattern(pattern, "pack")
 
-    # packing zero tensors is illegal
+    if len(tensors) == 0:
+        raise EinopsError("pack() requires at least one tensor, got empty list")
+
     backend = get_backend(tensors[0])
 
     reshaped_tensors: list[Tensor] = []

--- a/einops/parsing.py
+++ b/einops/parsing.py
@@ -130,7 +130,7 @@ class ParsedExpression:
         elif name[0] == "_" or name[-1] == "_":
             if name == "_" and allow_underscore:
                 return True, ""
-            return False, "axis name should should not start or end with underscore"
+            return False, "axis name should not start or end with underscore"
         else:
             if keyword.iskeyword(name):
                 warnings.warn(


### PR DESCRIPTION
## Changes

1. **pack() empty list fix**: `pack([], ...)` now raises clear `EinopsError` instead of `IndexError: list index out of range`
2. **Typo fix**: "should should" → "should" in parsing.py

## Testing

Existing tests pass.