### PR TITLE
Docs: Missing docstring for apply_for_scriptable_torch function

### DIFF
--- a/einops/_torch_specific.py
+++ b/einops/_torch_specific.py
@@ -77,6 +77,23 @@ class TorchJitBackend:
 def apply_for_scriptable_torch(
     recipe: TransformRecipe, tensor: torch.Tensor, reduction_type: str, axes_dims: list[tuple[str, int]]
 ) -> torch.Tensor:
+    """
+    Apply an einops transformation recipe to a tensor using only torchscript-compatible operations.
+
+    This function mirrors ``einops.einops._apply_recipe`` but uses ``TorchJitBackend``
+    so that the result can be scripted with ``torch.jit.script``.
+
+    Args:
+        recipe: A parsed ``TransformRecipe`` describing the transformation.
+        tensor: Input tensor to transform.
+        reduction_type: Reduction operation name (e.g. ``'min'``, ``'max'``, ``'sum'``,
+            ``'mean'``, ``'prod'``).  Ignored when the recipe contains no reduced axes.
+        axes_dims: List of ``(axis_name, axis_length)`` pairs providing concrete
+            dimension sizes for named axes.
+
+    Returns:
+        Transformed tensor after reshape, transpose, reduction, and added-axes steps.
+    """
     backend = TorchJitBackend
     (
         init_shapes,


### PR DESCRIPTION
## Problem

The public function apply_for_scriptable_torch lacks a docstring. This function is part of the torch.jit.script integration and users may need to understand its purpose and parameters for custom scripting scenarios.

**Severity**: `medium`
**File**: `einops/_torch_specific.py`

## Solution

Add a docstring explaining the function's purpose, parameters, return type, and usage context with torch.jit.script.

## Changes

- `einops/_torch_specific.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
