### PR TITLE
docs: document expand/broadcast semantics of einops.repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Kapil Sachdeva recorded a small [intro to einops](https://www.youtube.com/watch?
 `einops` has a minimalistic yet powerful API.
 
 Three core operations provided ([einops tutorial](https://github.com/arogozhnikov/einops/blob/main/docs/)
-shows those cover stacking, reshape, transposition, squeeze/unsqueeze, repeat, tile, concatenate, view and numerous reductions)
+shows those cover stacking, reshape, transposition, squeeze/unsqueeze, repeat, tile, broadcast, concatenate, view and numerous reductions)
 
 ```python
 from einops import rearrange, reduce, repeat

--- a/einops/einops.py
+++ b/einops/einops.py
@@ -661,6 +661,13 @@ def repeat(tensor: Tensor | list[Tensor], pattern: str, **axes_lengths: Size) ->
     When composing axes, C-order enumeration used (consecutive elements have different last axis).
     Find more examples in einops tutorial.
 
+    einops.repeat can introduce axes that are not present in the input (for example
+    `c` in `'h w -> h w c'`), filling them by repeating the data. This covers the
+    expand/broadcast use cases (such as `numpy.broadcast_to` or `torch.expand`) in
+    addition to repeat and tile. Whether the repeated elements are a materialized copy
+    or a memory-sharing view depends on the backend (numpy returns a copy, some
+    frameworks return an expanded view), so treat the output as a new tensor.
+
     Parameters:
         tensor: tensor of any supported library (e.g. numpy.ndarray, tensorflow, pytorch).
             list of tensors is also accepted, those should be of the same type and shape


### PR DESCRIPTION
Per #351, the expand-like behavior of `einops.repeat` has come up several times in issues and was not stated in the docs. This documents that `repeat` can introduce axes that are not present in the input and fill them by repetition, covering the `numpy.broadcast_to` / `torch.expand` use cases in addition to repeat and tile.

- Adds one paragraph to the `repeat` docstring: it can create new output axes by repeating the data, and whether the repeated elements are a materialized copy or a memory-sharing view depends on the backend (numpy returns a copy, some frameworks return an expanded view).
- Adds `broadcast` to the operations list in the README, alongside the existing `repeat` and `tile`.

Docs only, no behavior change. Happy to drop the README line if you would prefer the docstring change only.

Closes #351
