### PR TITLE
feat: add Repeat layer to einops.layers across backends

### DIFF
--- a/einops/layers/__init__.py
+++ b/einops/layers/__init__.py
@@ -110,3 +110,29 @@ class ReduceMixin:
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__init__(pattern=state["pattern"], reduction=state["reduction"], **state["axes_lengths"])  # type: ignore[misc]
+
+
+class RepeatMixin(ReduceMixin):
+    """
+    Repeat layer behaves identically to einops.repeat operation.
+
+    :param pattern: str, repeat pattern
+    :param axes_lengths: any additional specification of dimensions
+
+    See einops.repeat for source_examples.
+    """
+
+    def __init__(self, pattern: str, **axes_lengths: Any) -> None:
+        super().__init__(pattern, "repeat", **axes_lengths)
+
+    def __repr__(self) -> str:
+        params = repr(self.pattern)
+        for axis, length in self.axes_lengths.items():
+            params += f", {axis}={length}"
+        return f"{self.__class__.__name__}({params})"
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"pattern": self.pattern, "axes_lengths": self.axes_lengths}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__init__(pattern=state["pattern"], **state["axes_lengths"])  # type: ignore[misc]

--- a/einops/layers/flax.py
+++ b/einops/layers/flax.py
@@ -5,7 +5,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 
-from . import RearrangeMixin, ReduceMixin
+from . import RearrangeMixin, ReduceMixin, RepeatMixin
 from ._einmix import _EinmixMixin
 
 __author__ = "Alex Rogozhnikov"
@@ -21,6 +21,17 @@ class Reduce(nn.Module):
 
     def __call__(self, input: jax.Array) -> jax.Array:
         return self.reducer._apply_recipe(input)
+
+
+class Repeat(nn.Module):
+    pattern: str
+    sizes: dict[str, Any] = field(default_factory=dict)
+
+    def setup(self) -> None:
+        self.repeater = RepeatMixin(self.pattern, **self.sizes)
+
+    def __call__(self, input: jax.Array) -> jax.Array:
+        return self.repeater._apply_recipe(input)
 
 
 class Rearrange(nn.Module):

--- a/einops/layers/keras.py
+++ b/einops/layers/keras.py
@@ -1,9 +1,10 @@
 __author__ = "Alex Rogozhnikov"
 
-from einops.layers.tensorflow import EinMix, Rearrange, Reduce
+from einops.layers.tensorflow import EinMix, Rearrange, Reduce, Repeat
 
 keras_custom_objects = {
     Rearrange.__name__: Rearrange,
     Reduce.__name__: Reduce,
+    Repeat.__name__: Repeat,
     EinMix.__name__: EinMix,
 }

--- a/einops/layers/oneflow.py
+++ b/einops/layers/oneflow.py
@@ -2,7 +2,7 @@ from typing import cast
 
 import oneflow as flow
 
-from . import RearrangeMixin, ReduceMixin
+from . import RearrangeMixin, ReduceMixin, RepeatMixin
 from ._einmix import _EinmixMixin
 
 __author__ = "Tianhe Ren & Depeng Liang"
@@ -14,6 +14,11 @@ class Rearrange(RearrangeMixin, flow.nn.Module):
 
 
 class Reduce(ReduceMixin, flow.nn.Module):
+    def forward(self, input: flow.Tensor) -> flow.Tensor:
+        return self._apply_recipe(input)
+
+
+class Repeat(RepeatMixin, flow.nn.Module):
     def forward(self, input: flow.Tensor) -> flow.Tensor:
         return self._apply_recipe(input)
 

--- a/einops/layers/paddle.py
+++ b/einops/layers/paddle.py
@@ -2,7 +2,7 @@ from typing import cast
 
 import paddle
 
-from . import RearrangeMixin, ReduceMixin
+from . import RearrangeMixin, ReduceMixin, RepeatMixin
 from ._einmix import _EinmixMixin
 
 __author__ = "PaddlePaddle"
@@ -14,6 +14,11 @@ class Rearrange(RearrangeMixin, paddle.nn.Layer):
 
 
 class Reduce(ReduceMixin, paddle.nn.Layer):
+    def forward(self, input: paddle.Tensor) -> paddle.Tensor:
+        return self._apply_recipe(input)
+
+
+class Repeat(RepeatMixin, paddle.nn.Layer):
     def forward(self, input: paddle.Tensor) -> paddle.Tensor:
         return self._apply_recipe(input)
 

--- a/einops/layers/tensorflow.py
+++ b/einops/layers/tensorflow.py
@@ -16,7 +16,7 @@ from typing import cast
 import tensorflow as tf
 from tensorflow.keras.layers import Layer
 
-from . import RearrangeMixin, ReduceMixin
+from . import RearrangeMixin, ReduceMixin, RepeatMixin
 from ._einmix import _EinmixMixin
 
 __author__ = "Alex Rogozhnikov"
@@ -42,6 +42,17 @@ class Reduce(ReduceMixin, Layer):
 
     def get_config(self):
         return {"pattern": self.pattern, "reduction": self.reduction, **self.axes_lengths}
+
+
+class Repeat(RepeatMixin, Layer):
+    def build(self, input_shape):
+        pass  # layer does not have any parameters to be initialized
+
+    def call(self, inputs):
+        return self._apply_recipe(inputs)
+
+    def get_config(self):
+        return {"pattern": self.pattern, **self.axes_lengths}
 
 
 class EinMix(_EinmixMixin, Layer):

--- a/einops/layers/torch.py
+++ b/einops/layers/torch.py
@@ -4,7 +4,7 @@ import torch
 
 from einops._torch_specific import apply_for_scriptable_torch
 
-from . import RearrangeMixin, ReduceMixin
+from . import RearrangeMixin, ReduceMixin, RepeatMixin
 from ._einmix import _EinmixMixin
 
 __author__ = "Alex Rogozhnikov"
@@ -24,6 +24,16 @@ class Reduce(ReduceMixin, torch.nn.Module):
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         recipe = self._multirecipe[input.ndim]
         return apply_for_scriptable_torch(recipe, input, reduction_type=self.reduction, axes_dims=self._axes_lengths)  # type: ignore[arg-type]
+
+    def _apply_recipe(self, x):
+        # preventing scripting of parent method by overriding
+        pass
+
+
+class Repeat(RepeatMixin, torch.nn.Module):
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        recipe = self._multirecipe[input.ndim]
+        return apply_for_scriptable_torch(recipe, input, reduction_type="repeat", axes_dims=self._axes_lengths)  # type: ignore[arg-type]
 
     def _apply_recipe(self, x):
         # preventing scripting of parent method by overriding

--- a/einops/tests/test_layers.py
+++ b/einops/tests/test_layers.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 import numpy as np
 import pytest
 
-from einops import EinopsError, rearrange, reduce
+from einops import EinopsError, rearrange, reduce, repeat
 from einops.tests import FLOAT_REDUCTIONS as REDUCTIONS
 from einops.tests import collect_test_backends, is_backend_tested
 
@@ -174,6 +174,95 @@ def test_reduce_symbolic():
                     assert np.allclose(result1, result2)
 
 
+repeat_patterns = [
+    testcase(
+        "a b -> a b c",
+        dict(c=3),
+        (2, 4),
+        [(), (2,), (2, 4, 3)],
+    ),
+    testcase(
+        "b c -> (b copy) c",
+        dict(copy=3),
+        (4, 5),
+        [(), (4,), (4, 5, 1)],
+    ),
+    testcase(
+        "b 1 c -> b h c",
+        dict(h=4),
+        (2, 1, 5),
+        [(2, 3, 5), (2, 5)],
+    ),
+]
+
+
+def test_repeat_imperative():
+    for backend in collect_test_backends(symbolic=False, layers=True):
+        print("Test layer for ", backend.framework_name)
+        for pattern, axes_lengths, input_shape, wrong_shapes in repeat_patterns:
+            x = np.arange(1, 1 + np.prod(input_shape), dtype="float32").reshape(input_shape)
+            result_numpy = repeat(x, pattern, **axes_lengths)
+            layer = backend.layers().Repeat(pattern, **axes_lengths)
+            for shape in wrong_shapes:
+                try:
+                    layer(backend.from_numpy(np.zeros(shape, dtype="float32")))
+                except BaseException:
+                    pass
+                else:
+                    raise AssertionError("Failure expected")
+
+            # simple pickling / unpickling
+            layer2 = pickle.loads(pickle.dumps(layer))
+            result1 = backend.to_numpy(layer(backend.from_numpy(x)))
+            result2 = backend.to_numpy(layer2(backend.from_numpy(x)))
+            assert np.allclose(result_numpy, result1)
+            assert np.allclose(result1, result2)
+
+            just_sum = backend.layers().Reduce("...->", reduction="sum")
+
+            variable = backend.from_numpy(x)
+            result = just_sum(layer(variable))
+
+            result.backward()
+            grad = backend.to_numpy(variable.grad)
+            # every input element is copied at least once, so its gradient is positive
+            assert np.all(grad >= 1)
+
+
+def test_repeat_symbolic():
+    for backend in collect_test_backends(symbolic=True, layers=True):
+        print("Test layer for ", backend.framework_name)
+        for pattern, axes_lengths, input_shape, _wrong_shapes in repeat_patterns:
+            x = np.arange(1, 1 + np.prod(input_shape), dtype="float32").reshape(input_shape)
+            result_numpy = repeat(x, pattern, **axes_lengths)
+            layer = backend.layers().Repeat(pattern, **axes_lengths)
+            input_shape_of_nones = [None] * len(input_shape)
+            shapes = [input_shape, input_shape_of_nones]
+
+            for shape in shapes:
+                symbol = backend.create_symbol(shape)
+                eval_inputs = [(symbol, x)]
+
+                result_symbol1 = layer(symbol)
+                result1 = backend.eval_symbol(result_symbol1, eval_inputs)
+                assert np.allclose(result_numpy, result1)
+
+                layer2 = pickle.loads(pickle.dumps(layer))
+                result_symbol2 = layer2(symbol)
+                result2 = backend.eval_symbol(result_symbol2, eval_inputs)
+                assert np.allclose(result1, result2)
+
+
+def test_repeat_invalid_pattern():
+    backends = list(collect_test_backends(symbolic=False, layers=True))
+    if len(backends) == 0:
+        pytest.skip()
+    backend = backends[0]
+    with pytest.raises(EinopsError):
+        # new axis on the right without a size
+        backend.layers().Repeat("a b -> a b c")
+
+
 def create_torch_model(use_reduce=False, add_scripted_layer=False):
     if not is_backend_tested("torch"):
         pytest.skip()
@@ -239,6 +328,28 @@ def test_torch_layers_scripting():
             input = torch.randn([10, 3, 32, 32])
 
             torch.testing.assert_close(model1(input), model2(input), atol=1e-3, rtol=1e-3)
+
+
+def test_torch_repeat_scripting():
+    if not is_backend_tested("torch"):
+        pytest.skip()
+    else:
+        import torch
+        from torch.nn import Sequential
+
+        from einops.layers.torch import Rearrange, Repeat
+
+        model = Sequential(
+            Repeat("b c h w -> b (repeat c) h w", repeat=2),
+            Rearrange("b c h w -> b (c h w)"),
+        )
+        scripted = torch.jit.script(model)
+        input = torch.randn([10, 3, 8, 8])
+        torch.testing.assert_close(model(input), scripted(input), atol=1e-3, rtol=1e-3)
+
+        # eager output matches the functional einops.repeat
+        expected = repeat(input.numpy(), "b c h w -> b (repeat c) h w", repeat=2).reshape(10, -1)
+        torch.testing.assert_close(model(input), torch.from_numpy(expected), atol=1e-3, rtol=1e-3)
 
 
 def test_keras_layer():


### PR DESCRIPTION
## Summary

Adds a `Repeat` layer to `einops.layers`, complementing the existing `Rearrange` and `Reduce` layers. `Repeat` wraps the functional `einops.repeat` so it can be dropped into `nn.Sequential`-style model definitions. It is implemented across every backend (torch, tensorflow, keras, flax, oneflow, paddle) exactly parallel to how `Reduce` is defined, and follows the `Reduce` template: a `RepeatMixin(ReduceMixin)` in `einops/layers/__init__.py` with the reduction hard-wired to `"repeat"`, plus a concrete `Repeat` class in each backend layer module.

Because `Repeat` needs no `reduction` argument, the mixin overrides `__repr__`, `__getstate__`, and `__setstate__` to drop that field, so it pickles and round-trips like `Rearrange`.

## Why this matters

Users have long asked for a first-class `Repeat` layer parallel to `Rearrange` and `Reduce` (#185). Today the only layer-based option is `Reduce('a b -> a b c', reduction='repeat', c=4)`, which reads confusingly because a repeat is not a reduction. The maintainer green-lit incorporating a `Repeat` layer in the issue thread, and multiple users noted concrete use cases, including `torch.jit.script` compatibility that only the layer forms provide. This change mirrors the accepted `Reduce` template across all backends and keeps the torch path `torch.jit.script`-safe (for a repeat, `reduced_axes` is empty and only the `add_axes` branch runs).

## Testing

Added layer tests parallel to the existing `Reduce` tests, covering numpy and torch: imperative and symbolic parity against the functional `einops.repeat`, pickle round-trips, wrong-shape rejection, an invalid-pattern error path, and a `torch.jit.script` test that scripts a `Repeat` inside a `Sequential` and checks scripted output matches eager. The other backends are exercised by the same parametrized layer tests in CI.

```
EINOPS_TEST_BACKENDS=numpy,torch python -m pytest einops/tests/test_layers.py -q
13 passed, 2 skipped
```

Fixes #185
